### PR TITLE
Claude Pocket — déclencher les agents cloud depuis l'iPhone

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/pocket-task.yml
+++ b/.github/ISSUE_TEMPLATE/pocket-task.yml
@@ -31,6 +31,19 @@ body:
     validations:
       required: false
   - type: dropdown
+    id: workflow
+    attributes:
+      label: Workflow (recette)
+      description: "Recette métier câblée. 'auto' = Dispatch détecte/route seul."
+      options:
+        - "auto"
+        - "repondre-collegue"
+        - "enrichir-contact"
+        - "diagnostic-sequence"
+      default: 0
+    validations:
+      required: false
+  - type: dropdown
     id: agent_hint
     attributes:
       label: Agent (optionnel)

--- a/.github/ISSUE_TEMPLATE/pocket-task.yml
+++ b/.github/ISSUE_TEMPLATE/pocket-task.yml
@@ -1,0 +1,47 @@
+name: "📱 Pocket Task"
+description: "Déclencher Claude depuis le téléphone — pose une demande ou colle une question collègue."
+title: "[Pocket] "
+labels: ["agent", "pocket"]
+body:
+  - type: textarea
+    id: demande
+    attributes:
+      label: Demande
+      description: "La tâche ou la question (colle ici le message Slack du collègue si besoin)."
+      placeholder: "Ex : Pourquoi le contact X n'apparaît pas dans la séquence Y ?"
+    validations:
+      required: true
+  - type: dropdown
+    id: write_allowed
+    attributes:
+      label: Autoriser l'écriture ?
+      description: "Par défaut NON — Claude se contente de lire et proposer. Mets OUI seulement si tu veux qu'il modifie quelque chose (toujours derrière une approbation)."
+      options:
+        - "non"
+        - "oui"
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: write_conditions
+    attributes:
+      label: Conditions d'écriture (si OUI)
+      description: "Décris précisément ce qu'il a le droit de modifier, et les limites. Ces conditions doivent être respectées à la lettre."
+      placeholder: "Ex : tu peux mettre lifecyclestage à 'lead', jamais l'écraser s'il est déjà rempli. Rien d'autre."
+    validations:
+      required: false
+  - type: dropdown
+    id: agent_hint
+    attributes:
+      label: Agent (optionnel)
+      description: "Laisse 'auto' pour que Dispatch route tout seul."
+      options:
+        - "auto"
+        - "crm (HubSpot / leads)"
+        - "ads (Google Ads)"
+        - "web (recherche / enrichissement)"
+        - "email"
+        - "code"
+      default: 0
+    validations:
+      required: false

--- a/.github/workflows/_reusable-claude.yml
+++ b/.github/workflows/_reusable-claude.yml
@@ -47,7 +47,8 @@ jobs:
             @modelcontextprotocol/server-github \
             @playwright/mcp \
             firecrawl-mcp \
-            @modelcontextprotocol/server-memory
+            @modelcontextprotocol/server-memory \
+            @hubspot/mcp-server
 
       - uses: actions/setup-python@v5
         with:
@@ -64,6 +65,8 @@ jobs:
         env:
           GH_TOKEN_MCP: ${{ secrets.GITHUB_TOKEN }}
           FIRECRAWL_KEY_MCP: ${{ secrets.FIRECRAWL_API_KEY }}
+          HUBSPOT_TOKEN_MCP: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
+          LEMLIST_KEY_MCP: ${{ secrets.LEMLIST_API_KEY }}
         run: |
           python3 -c "
           import json, os
@@ -74,12 +77,21 @@ jobs:
             'firecrawl': {'command': 'npx', 'args': ['-y', 'firecrawl-mcp'], 'env': {'FIRECRAWL_API_KEY': os.environ.get('FIRECRAWL_KEY_MCP', '')}},
             'memory': {'command': 'npx', 'args': ['-y', '@modelcontextprotocol/server-memory'], 'env': {}}
           }}
+          # HubSpot MCP — branché seulement si le secret est présent
+          if os.environ.get('HUBSPOT_TOKEN_MCP'):
+              cfg['mcpServers']['hubspot'] = {'command': 'npx', 'args': ['-y', '@hubspot/mcp-server'], 'env': {'PRIVATE_APP_ACCESS_TOKEN': os.environ['HUBSPOT_TOKEN_MCP']}}
+          # Lemlist MCP (HTTP) — branché seulement si le secret est présent
+          if os.environ.get('LEMLIST_KEY_MCP'):
+              cfg['mcpServers']['lemlist'] = {'type': 'http', 'url': 'https://app.lemlist.com/mcp', 'headers': {'X-API-Key': os.environ['LEMLIST_KEY_MCP']}}
           json.dump(cfg, open('/tmp/mcp-config.json', 'w'))
           "
 
       - name: Build claude_args
         run: |
-          BASE="Bash,Read,Write,Edit,mcp__filesystem__read_file,mcp__filesystem__write_file,mcp__github__add_issue_comment,mcp__memory__add_observations,mcp__memory__search_nodes"
+          # HubSpot + Lemlist : SEULEMENT les outils LECTURE sont auto-autorisés ici.
+          # Les outils d'écriture passent par l'input allowed_tools, et restent gated par approbation (label `approved`).
+          READONLY="mcp__hubspot__hubspot-search-objects,mcp__hubspot__hubspot-list-objects,mcp__hubspot__hubspot-batch-read-objects,mcp__hubspot__hubspot-list-properties,mcp__hubspot__hubspot-get-property,mcp__hubspot__hubspot-get-schemas,mcp__hubspot__hubspot-list-associations,mcp__hubspot__hubspot-list-workflows,mcp__hubspot__hubspot-get-workflow,mcp__lemlist__get_campaigns,mcp__lemlist__get_campaign_details,mcp__lemlist__get_campaigns_stats,mcp__lemlist__search_contacts,mcp__lemlist__get_inbox_conversations"
+          BASE="Bash,Read,Write,Edit,mcp__filesystem__read_file,mcp__filesystem__write_file,mcp__github__add_issue_comment,mcp__memory__add_observations,mcp__memory__search_nodes,$READONLY"
           EXTRA="${{ inputs.allowed_tools }}"
           if [[ "$EXTRA" == "none" || -z "$EXTRA" ]]; then
             TOOLS="$BASE"

--- a/.github/workflows/_reusable-claude.yml
+++ b/.github/workflows/_reusable-claude.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "none"
+      model:
+        required: false
+        type: string
+        default: "claude-haiku-4-5"
     outputs:
       result_json:
         description: "Agent result as JSON string"
@@ -82,13 +86,16 @@ jobs:
           else
             TOOLS="$BASE,$EXTRA"
           fi
-          echo "CLAUDE_ARGS=--max-turns ${{ inputs.max_turns }} --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
+          echo "CLAUDE_ARGS=--model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
 
       - name: Run Claude agent
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth commutable : secret vide = abonnement (OAuth, 0 €) ; rempli = API métré.
+          # Bascule plan SDK = remplir/vider ce seul secret, aucun autre changement de code.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             AGENT_ROLE: ${{ inputs.agent_role }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -28,6 +28,20 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"],
       "env": {}
+    },
+    "hubspot": {
+      "command": "npx",
+      "args": ["-y", "@hubspot/mcp-server"],
+      "env": {
+        "PRIVATE_APP_ACCESS_TOKEN": "${HUBSPOT_PRIVATE_APP_TOKEN}"
+      }
+    },
+    "lemlist": {
+      "type": "http",
+      "url": "https://app.lemlist.com/mcp",
+      "headers": {
+        "X-API-Key": "${LEMLIST_API_KEY}"
+      }
     }
   }
 }

--- a/agent_prompts/dispatch.md
+++ b/agent_prompts/dispatch.md
@@ -289,3 +289,19 @@ Si l'issue porte le label **`pocket`** (déclenchée depuis le téléphone), app
 6. **Résultat final** → commentaire clair sur l'issue (c'est ce que l'utilisateur lira sur son téléphone), + `/tmp/agent_result.json` rempli avec `retrospective`.
 
 Le routage `Agent` n'est qu'un indice : `auto` = tu décides. crm→Aria, ads→Nexus, web→Scout, email→Iris, code→Forge.
+
+### Workflows métier (recettes câblées)
+
+Si le corps de l'issue contient un champ **`Workflow`** valant autre chose que `auto`, **charge le playbook correspondant et suis-le à la lettre** :
+
+| Workflow | Playbook | Type |
+|---|---|---|
+| `repondre-collegue` | `agent_prompts/workflows/repondre-collegue.md` | lecture seule |
+| `enrichir-contact` | `agent_prompts/workflows/enrichir-contact.md` | écriture possible (Aria) |
+| `diagnostic-sequence` | `agent_prompts/workflows/diagnostic-sequence.md` | lecture seule |
+
+```bash
+cat agent_prompts/workflows/<workflow>.md
+```
+
+Si `Workflow = auto`, détecte toi-même la recette si la demande correspond clairement (question collègue avec lien HubSpot → `repondre-collegue` ; lien `/sequences/` → `diagnostic-sequence` ; « enrichir / compléter des contacts » → `enrichir-contact`). Sinon, routage normal. Les garde-fous Pocket s'appliquent toujours par-dessus le playbook.

--- a/agent_prompts/dispatch.md
+++ b/agent_prompts/dispatch.md
@@ -270,3 +270,22 @@ Si un secret requis manque → informer sur l'issue + documenter les prochaines 
 3. **Lire `memory/lessons_learned.md`** avant toute tâche complexe
 4. **Documenter les erreurs** dans `/tmp/agent_result.json` même en cas d'échec
 5. **Maximum 12 turns** pour les tâches complexes — escalader si blocage
+
+---
+
+## 📱 Mode Pocket (issues label `pocket`)
+
+Si l'issue porte le label **`pocket`** (déclenchée depuis le téléphone), applique strictement ce protocole :
+
+1. **Lire `docs/runner-guardrails.md`** avant toute action — garde-fous durs non négociables.
+2. **Parser le corps de l'issue** : champs `Demande`, `Autoriser l'écriture ?` (oui/non), `Conditions d'écriture`, `Agent`.
+3. **Règle d'or :**
+   - `Autoriser l'écriture ? = non` → **lecture / proposition uniquement**. Produis une réponse prête à copier (réponse au collègue, diagnostic, analyse). N'écris RIEN à l'extérieur.
+   - `Autoriser l'écriture ? = oui` → tu peux préparer une écriture, mais **uniquement dans les `Conditions d'écriture` fournies**, et **uniquement après** :
+     a) avoir posté un **preview** en commentaire (« 🔍 Preview — je vais faire : … »),
+     b) attendu le label **`approved`** sur l'issue. Sans `approved`, reste en `DRY_RUN`.
+4. **Toujours respecter les garde-fous durs** (jamais écraser un champ rempli, FullEnrich ≤100, 207 = succès partiel, Lemlist irréversible = preview obligatoire, etc.).
+5. **Secret manquant** → commenter « secret `X` absent, action non exécutée », ne pas planter.
+6. **Résultat final** → commentaire clair sur l'issue (c'est ce que l'utilisateur lira sur son téléphone), + `/tmp/agent_result.json` rempli avec `retrospective`.
+
+Le routage `Agent` n'est qu'un indice : `auto` = tu décides. crm→Aria, ads→Nexus, web→Scout, email→Iris, code→Forge.

--- a/agent_prompts/workflows/diagnostic-sequence.md
+++ b/agent_prompts/workflows/diagnostic-sequence.md
@@ -1,0 +1,41 @@
+# Workflow — Diagnostic de séquence HubSpot
+
+**Type :** LECTURE SEULE. Tu diagnostiques pourquoi une séquence se comporte d'une certaine façon et tu rends une explication claire + une réponse au demandeur.
+
+## Objectif
+Répondre aux questions du type « pourquoi ce contact n'apparaît pas dans la séquence ? », « pourquoi le tracking est cassé ? », « pourquoi il n'a pas reçu l'email suivant ? ». Tu enquêtes côté HubSpot **en lecture** et tu expliques.
+
+## Entrée
+Le champ `Demande` contient la question + souvent un lien séquence (`/sequences/4550859/sequence/<id>`) et/ou un lien contact.
+
+## Étapes
+1. **Garde-fous** : `cat docs/runner-guardrails.md`.
+2. **Lire la note de référence** si dispo : `docs/vault/.../HubSpot-Sequences-Meeting-Attribution.md` (ou vault `03-Playbooks/02-Sales-CRM/`) — règles d'inscription/désinscription et **fenêtre d'attribution meeting 7 j post-unenroll**.
+3. **Lire la séquence et les enrollments** (HubSpot MCP, lecture) :
+   - `hubspot-list-workflows` / `hubspot-get-workflow` pour le contexte automation lié.
+   - `hubspot-batch-read-objects` + `hubspot-list-associations` sur le(s) contact(s) cité(s) : statut d'enrollment, `hs_sequences_*`, dernières activités email (open/click/bounce/reply), meetings.
+   - `hubspot-get-engagement` si un engagement précis est en cause.
+4. **Diagnostiquer** parmi les causes fréquentes :
+   - Contact **déjà inscrit** ailleurs / **désinscrit** (reply, meeting booked, bounce, manual unenroll).
+   - **Critères d'inscription** non remplis (propriété manquante, owner, filtre).
+   - **Tracking** : email non ouvert ≠ non délivré ; pixel bloqué ; domaine d'envoi.
+   - **Attribution meeting** : meeting pris dans la **fenêtre 7 j** après désinscription → compte quand même.
+5. **Rédiger l'explication** : cause probable + preuve (ce que tu as lu) + action recommandée.
+
+## Garde-fous spécifiques
+- **Zéro écriture / zéro modification de séquence.** Tu expliques et recommandes, tu ne touches à rien.
+- Distinguer clairement **fait observé** (« le contact est unenrolled depuis le 12/06 ») de **hypothèse** (« probablement à cause d'un reply »).
+
+## Sortie (commentaire d'issue)
+```
+## 🔎 Diagnostic séquence
+
+**Cause :** <la cause identifiée>
+**Preuves :** <ce que tu as lu dans HubSpot — ids, statuts, dates>
+**Recommandation :** <action concrète>
+
+---
+**💬 Réponse prête (au collègue) :**
+> <message court à copier, même langue que la question>
+```
+Puis `/tmp/agent_result.json` (`status: complete`, `retrospective`).

--- a/agent_prompts/workflows/enrichir-contact.md
+++ b/agent_prompts/workflows/enrichir-contact.md
@@ -1,0 +1,38 @@
+# Workflow — Enrichir un (des) contact(s)
+
+**Type :** LECTURE par défaut · ÉCRITURE possible (FullEnrich → HubSpot) **seulement si** `Autoriser l'écriture = oui` + conditions + label `approved`. Agent porteur : **Aria**.
+
+## Objectif
+Compléter des contacts HubSpot incomplets (email pro, téléphone mobile, LinkedIn, taille, industrie…) via FullEnrich, **sans jamais écraser une donnée existante**, en respectant l'ICP et le mapping EMAsphere.
+
+## Entrée
+Le champ `Demande` désigne la cible : un email/nom, une liste, ou un segment HubSpot (« les contacts sans téléphone de la company X »). Les `Conditions d'écriture` bornent ce qui peut être modifié.
+
+## Étapes
+1. **Garde-fous** : `cat docs/runner-guardrails.md` + `cat ~/crm-context/icp_and_data_rules.md` si présent (sinon vault).
+2. **Lire l'existant** (HubSpot, lecture) : `hubspot-search-objects` / `hubspot-batch-read-objects` → repérer **les champs VIDES** à compléter (GF #1 : ne jamais écraser un champ rempli).
+3. **Enrichir via FullEnrich** (Python direct, API v2) :
+   - Par lots de **≤ 100 contacts** (GF #6).
+   - Téléphone : ne garder que le **mobile** (politique FullEnrich vault).
+4. **Mapper vers HubSpot** :
+   - Industry → `industry_emalist` sur **Companies** (format « Catégorie - Sous-catégorie », mapping IndustryDB). ⚠️ ne pas écrire si nom de champ non confirmé en prod.
+   - `numemployees` = range ; nombre brut → `linkedin_employee_count`.
+   - `country` = enum strict (sinon `country_code`). `domain` = extrait de l'email (pas de propriété contact).
+5. **Preview obligatoire** (commentaire) : tableau des updates proposés (contact, champ, ancienne valeur=vide, nouvelle valeur). **Attendre `approved`.**
+6. **Exécuter** (si `approved`) : `hubspot-batch-update-objects` **non destructif** (champs vides uniquement). Traiter **207 = succès partiel** (GF #7), logguer les `results`.
+
+## Garde-fous spécifiques
+- Jamais écraser un champ rempli (revérifier juste avant l'update).
+- Respecter strictement les `Conditions d'écriture` (ex : « seulement le téléphone »).
+- Hors ICP (CA < 10M ou > 500M) → signaler, ne pas forcer.
+
+## Sortie (commentaire d'issue)
+```
+## 🔍 Preview enrichissement (N contacts)
+| Contact | Champ | Nouvelle valeur |
+|---|---|---|
+| … | mobilephone | +32… |
+
+**Tape ✅ Approuver pour exécuter** (sinon DRY_RUN).
+```
+Après exécution : commentaire récap (X mis à jour, Y inchangés, Z échecs) + `/tmp/agent_result.json`.

--- a/agent_prompts/workflows/repondre-collegue.md
+++ b/agent_prompts/workflows/repondre-collegue.md
@@ -1,0 +1,39 @@
+# Workflow — Répondre à un collègue
+
+**Type :** LECTURE SEULE. Aucune écriture externe, jamais. Tu produis une réponse prête à copier-coller dans Slack.
+
+## Objectif
+Un collègue (équipe Sales/CS EMAsphere) a posé une question, souvent en collant un lien HubSpot. Tu enquêtes côté CRM **en lecture**, tu comprends la situation, et tu rédiges **la réponse que Gaspard enverra au collègue**.
+
+## Entrée
+Le champ `Demande` de l'issue contient la question, parfois avec un lien HubSpot (`https://app.hubspot.com/contacts/4550859/record/0-1/<id>`, `/sequences/4550859/sequence/<id>`, deal, company…). La question peut être en FR ou EN.
+
+## Étapes
+1. **Charger les garde-fous** : `cat docs/runner-guardrails.md`.
+2. **Identifier l'objet** depuis le lien ou le texte :
+   - `record/0-1/<id>` = **contact**, `0-2` = **company**, `0-3` = **deal**.
+   - `/sequences/.../sequence/<id>` = séquence → bascule plutôt sur le workflow `diagnostic-sequence`.
+3. **Lire l'objet et son contexte** (HubSpot MCP, lecture) :
+   - `hubspot-batch-read-objects` sur l'id (propriétés pertinentes : email, lifecyclestage, hs_lead_status, owner, dates d'activité…).
+   - `hubspot-list-associations` pour relier contact↔company↔deal si utile.
+   - `hubspot-search-objects` si seul un nom/email est donné (pas d'id).
+4. **Analyser** : reconstituer ce qui s'est passé (qui possède la fiche, statut, dernière activité, pourquoi le comportement observé).
+5. **Rédiger la réponse au collègue** :
+   - **Même langue que la question** (FR ou EN).
+   - Ton **humain, familier-pro, concis** — comme un message Slack entre collègues, pas un rapport.
+   - Donne la réponse + l'action concrète si pertinente, sans jargon technique inutile.
+
+## Garde-fous spécifiques
+- **Zéro écriture.** Même si `Autoriser l'écriture = oui`, ce workflow reste en lecture (il sert à formuler une réponse, pas à modifier le CRM). Si une modif CRM est nécessaire, **propose-la** dans la réponse, ne l'exécute pas.
+- Ne jamais inventer de donnée : si une info manque, dis-le (« je ne vois pas X dans la fiche »).
+
+## Sortie (commentaire d'issue)
+```
+## 💬 Réponse prête à envoyer
+
+> <le message à copier-coller pour le collègue>
+
+---
+**Contexte (pour toi, Gaspard) :** <2-4 lignes : ce que tu as trouvé, l'id consulté, ce qui reste incertain>
+```
+Puis remplir `/tmp/agent_result.json` (`status: complete`, `retrospective`).

--- a/docs/pocket-setup.md
+++ b/docs/pocket-setup.md
@@ -1,0 +1,75 @@
+# Claude Pocket — Guide de setup
+
+Étapes pour activer le système (≈ 15 min, une seule fois). Rien à installer sur le Mac : tout est dans GitHub + ton iPhone.
+
+## 1. Fusionner la branche
+
+```bash
+cd ~/agent-system
+git push -u origin claude-pocket
+# Ouvre la PR claude-pocket → main sur GitHub, puis merge.
+```
+
+Le merge sur `main` déclenche `deploy-pages.yml` qui publie la PWA.
+
+## 2. Activer GitHub Pages
+
+Repo → **Settings → Pages** → Source = **GitHub Actions** (le workflow `deploy-pages.yml` s'en charge).
+URL de la PWA : `https://<ton-user-github>.github.io/agent-system/pocket/`
+
+## 3. Créer les secrets (Settings → Secrets and variables → Actions → New repository secret)
+
+| Secret | Valeur | Obligatoire ? |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | ton token abonnement Claude | ✅ (sûrement déjà présent) |
+| `ANTHROPIC_API_KEY` | **laisser VIDE** (ne pas créer) | — bascule API plus tard |
+| `HUBSPOT_PRIVATE_APP_TOKEN` | PAT app privée HubSpot | pour les actions CRM |
+| `LEMLIST_API_KEY` | clé API Lemlist | pour Lemlist |
+| `FULLENRICH_API_KEY` | clé FullEnrich | pour l'enrichissement |
+| `PHANTOMBUSTER_API_KEY` | clé PhantomBuster | pour PhantomBuster |
+| `FIRECRAWL_API_KEY` | clé Firecrawl | recherche web (souvent déjà là) |
+| `GEMINI_API_KEY` | clé Gemini | gros fichiers (souvent déjà là) |
+
+> Tant qu'un secret manque, l'agent te le signale proprement (« secret X absent ») sans planter. Tu peux donc démarrer avec seulement HubSpot et ajouter les autres au fil de l'eau.
+
+## 4. Créer un PAT fine-grained pour la PWA
+
+GitHub → **Settings (compte) → Developer settings → Personal access tokens → Fine-grained tokens → Generate**
+
+- **Resource owner** : ton compte
+- **Repository access** : *Only select repositories* → `agent-system`
+- **Permissions → Repository** :
+  - **Issues** : Read and write
+  - **Actions** : Read and write
+  - **Metadata** : Read (auto)
+- Expiration : 90 jours (renouvelable). Copie le token (`github_pat_…`).
+
+## 5. Installer la PWA sur l'iPhone
+
+1. Ouvre `https://<user>.github.io/agent-system/pocket/` dans **Safari**.
+2. Bouton **Partager** → **Sur l'écran d'accueil**.
+3. Ouvre l'app depuis l'écran d'accueil → ⚙️ → renseigne :
+   - **Repo** : `GaspardCoche/agent-system`
+   - **GitHub PAT** : le token de l'étape 4
+   - **Enregistrer**.
+
+## 6. Premier test (sans risque)
+
+1. Tape une demande simple, laisse **Autoriser l'écriture = OFF**, **Dispatch**.
+2. Onglet **Actions** du repo → `Orchestrator` se lance.
+3. Un commentaire de planification apparaît sur l'issue → il remonte dans la PWA (poll 15 s).
+4. Pour une écriture : active le toggle + écris les conditions → l'agent poste un **preview** → tu tapes **✅ Approuver** → exécution.
+
+## Sécurité
+
+- Le PAT vit en `localStorage` sur ton iPhone (usage perso mono-appareil). Révocable à tout moment (Developer settings).
+- Les clés API métier sont en **secrets GitHub chiffrés**, jamais dans le code ni les logs.
+- Toute écriture externe est gated par le label `approved` (rien ne part sans ton tap).
+
+## Bascule abonnement → API (le jour où le plan SDK change)
+
+Remplir le secret `ANTHROPIC_API_KEY`. C'est tout — aucun code à changer. Le vider = retour à l'abonnement.
+
+## Coût
+
+≈ **0 €/mois** : compute via abonnement, GitHub Actions (2000 min/mois gratuits) + Pages gratuits. Seuls tes abonnements data existants (FullEnrich, PhantomBuster) restent à l'usage.

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -43,12 +43,13 @@ async function ensureLabels() {
 }
 
 // ── Composer : Dispatch ──────────────────────────────────────────────────
-function buildBody(demande, writeAllowed, conditions, agent) {
+function buildBody(demande, writeAllowed, conditions, workflow, agent) {
   // Mime le rendu d'un GitHub issue-form pour un parsing uniforme par Dispatch.
   return [
     '### Demande', '', demande, '',
     "### Autoriser l'écriture ?", '', writeAllowed ? 'oui' : 'non', '',
     "### Conditions d'écriture (si OUI)", '', conditions || '_No response_', '',
+    '### Workflow (recette)', '', workflow || 'auto', '',
     '### Agent (optionnel)', '', agent || 'auto', '',
   ].join('\n');
 }
@@ -59,6 +60,7 @@ async function dispatch() {
   if (!demande) { msg.className = 'msg err'; msg.textContent = 'Écris une demande.'; return; }
   const writeAllowed = $('write-allowed').checked;
   const conditions = $('conditions').value.trim();
+  const workflow = $('workflow').value;
   const agent = $('agent').value;
 
   msg.className = 'msg'; msg.textContent = '⏳ Envoi…';
@@ -69,7 +71,7 @@ async function dispatch() {
       method: 'POST',
       body: JSON.stringify({
         title,
-        body: buildBody(demande, writeAllowed, conditions, agent),
+        body: buildBody(demande, writeAllowed, conditions, workflow, agent),
         labels: ['agent', 'pocket'],
       }),
     });

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -1,0 +1,226 @@
+'use strict';
+
+// ── État & stockage local ────────────────────────────────────────────────
+const LS = {
+  get repo() { return localStorage.getItem('pocket_repo') || ''; },
+  set repo(v) { localStorage.setItem('pocket_repo', v); },
+  get pat() { return localStorage.getItem('pocket_pat') || ''; },
+  set pat(v) { localStorage.setItem('pocket_pat', v); },
+  get history() { try { return JSON.parse(localStorage.getItem('pocket_history') || '[]'); } catch { return []; } },
+  set history(v) { localStorage.setItem('pocket_history', JSON.stringify(v.slice(0, 50))); },
+};
+
+const $ = (id) => document.getElementById(id);
+let pollTimer = null;
+
+// ── Helper API GitHub ────────────────────────────────────────────────────
+async function gh(path, opts = {}) {
+  if (!LS.pat || !LS.repo) throw new Error('Configure le repo et le token (⚙️).');
+  const res = await fetch(`https://api.github.com/repos/${LS.repo}${path}`, {
+    ...opts,
+    headers: {
+      'Authorization': `Bearer ${LS.pat}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      ...(opts.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    let detail = '';
+    try { detail = (await res.json()).message || ''; } catch {}
+    throw new Error(`GitHub ${res.status} ${detail}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+// Crée les labels s'ils n'existent pas (idempotent)
+async function ensureLabels() {
+  for (const [name, color] of [['agent', '6aa3ff'], ['pocket', '8b5cf6'], ['approved', '3fb950']]) {
+    try { await gh('/labels', { method: 'POST', body: JSON.stringify({ name, color }) }); }
+    catch (e) { /* déjà existant (422) → ignore */ }
+  }
+}
+
+// ── Composer : Dispatch ──────────────────────────────────────────────────
+function buildBody(demande, writeAllowed, conditions, agent) {
+  // Mime le rendu d'un GitHub issue-form pour un parsing uniforme par Dispatch.
+  return [
+    '### Demande', '', demande, '',
+    "### Autoriser l'écriture ?", '', writeAllowed ? 'oui' : 'non', '',
+    "### Conditions d'écriture (si OUI)", '', conditions || '_No response_', '',
+    '### Agent (optionnel)', '', agent || 'auto', '',
+  ].join('\n');
+}
+
+async function dispatch() {
+  const demande = $('demande').value.trim();
+  const msg = $('composer-msg');
+  if (!demande) { msg.className = 'msg err'; msg.textContent = 'Écris une demande.'; return; }
+  const writeAllowed = $('write-allowed').checked;
+  const conditions = $('conditions').value.trim();
+  const agent = $('agent').value;
+
+  msg.className = 'msg'; msg.textContent = '⏳ Envoi…';
+  try {
+    await ensureLabels();
+    const title = '[Pocket] ' + demande.slice(0, 60).replace(/\n/g, ' ');
+    const issue = await gh('/issues', {
+      method: 'POST',
+      body: JSON.stringify({
+        title,
+        body: buildBody(demande, writeAllowed, conditions, agent),
+        labels: ['agent', 'pocket'],
+      }),
+    });
+    const hist = LS.history;
+    hist.unshift({ number: issue.number, title, created: Date.now(), writeAllowed });
+    LS.history = hist;
+    $('demande').value = ''; $('conditions').value = '';
+    $('write-allowed').checked = false; $('conditions-wrap').classList.add('hidden');
+    msg.className = 'msg ok'; msg.textContent = `✅ Tâche #${issue.number} envoyée.`;
+    renderHistory();
+    openDetail(issue.number);
+  } catch (e) {
+    msg.className = 'msg err'; msg.textContent = '❌ ' + e.message;
+  }
+}
+
+// ── Historique ───────────────────────────────────────────────────────────
+function renderHistory() {
+  const ul = $('history-list');
+  const hist = LS.history;
+  if (!hist.length) { ul.innerHTML = '<li class="empty">Aucune tâche pour l\'instant.</li>'; return; }
+  ul.innerHTML = '';
+  for (const h of hist) {
+    const li = document.createElement('li');
+    li.innerHTML = `<span class="t">#${h.number} ${escapeHtml(h.title.replace('[Pocket] ', ''))}</span>
+                    <span class="badge pending">ouvrir</span>`;
+    li.onclick = () => openDetail(h.number);
+    ul.appendChild(li);
+  }
+}
+
+// ── Détail d'une tâche ───────────────────────────────────────────────────
+async function openDetail(number) {
+  stopPoll();
+  show('detail');
+  $('detail-title').textContent = `Tâche #${number}`;
+  $('detail-meta').textContent = '⏳ Chargement…';
+  $('comments').innerHTML = '';
+  $('approve').classList.add('hidden');
+  $('detail-msg').textContent = '';
+
+  const load = async () => {
+    try {
+      const [issue, comments] = await Promise.all([
+        gh(`/issues/${number}`),
+        gh(`/issues/${number}/comments`),
+      ]);
+      const labels = issue.labels.map((l) => l.name);
+      const approved = labels.includes('approved');
+      $('detail-meta').innerHTML =
+        `État : <span class="badge ${issue.state}">${issue.state}</span> · ` +
+        `écriture : ${labels.includes('pocket') && issue.body.includes('\noui') ? 'autorisée' : 'non'}` +
+        (approved ? ' · ✅ approuvée' : '');
+
+      const c = $('comments');
+      c.innerHTML = '';
+      if (!comments.length) {
+        c.innerHTML = '<p class="empty">Pas encore de réponse — l\'agent travaille…</p>';
+      } else {
+        for (const cm of comments) {
+          const div = document.createElement('div');
+          div.className = 'comment';
+          div.innerHTML = `<div class="who">${escapeHtml(cm.user.login)}</div>${escapeHtml(cm.body)}`;
+          c.appendChild(div);
+        }
+      }
+      // Bouton approuver : si une demande d'approbation est détectée et pas encore approuvée
+      const needsApproval = comments.some((cm) => /preview|approb|approuv|approved/i.test(cm.body)) && !approved && issue.state === 'open';
+      $('approve').classList.toggle('hidden', !needsApproval);
+      $('approve').onclick = () => approve(number);
+    } catch (e) {
+      $('detail-msg').className = 'msg err';
+      $('detail-msg').textContent = '❌ ' + e.message;
+      stopPoll();
+    }
+  };
+
+  await load();
+  pollTimer = setInterval(load, 15000); // poll toutes les 15 s
+}
+
+async function approve(number) {
+  const m = $('detail-msg');
+  m.className = 'msg'; m.textContent = '⏳ Approbation…';
+  try {
+    await gh(`/issues/${number}/labels`, { method: 'POST', body: JSON.stringify({ labels: ['approved'] }) });
+    m.className = 'msg ok'; m.textContent = '✅ Approuvé — l\'agent va exécuter.';
+    $('approve').classList.add('hidden');
+  } catch (e) {
+    m.className = 'msg err'; m.textContent = '❌ ' + e.message;
+  }
+}
+
+function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+
+// ── Dictée vocale (Web Speech API) ───────────────────────────────────────
+function setupMic() {
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+  const mic = $('mic');
+  if (!SR) { mic.style.display = 'none'; return; }
+  const rec = new SR();
+  rec.lang = 'fr-FR'; rec.interimResults = true; rec.continuous = true;
+  let base = '';
+  let live = false;
+  rec.onresult = (e) => {
+    let txt = '';
+    for (let i = e.resultIndex; i < e.results.length; i++) txt += e.results[i][0].transcript;
+    $('demande').value = (base + ' ' + txt).trim();
+  };
+  rec.onend = () => { live = false; mic.classList.remove('live'); };
+  mic.onclick = () => {
+    if (live) { rec.stop(); return; }
+    base = $('demande').value;
+    try { rec.start(); live = true; mic.classList.add('live'); } catch {}
+  };
+}
+
+// ── Navigation & UI ──────────────────────────────────────────────────────
+function show(which) {
+  // 'detail' = vue détail ; sinon vue principale
+  $('detail').classList.toggle('hidden', which !== 'detail');
+  for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', which === 'detail');
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────
+function init() {
+  // Réglages
+  $('repo').value = LS.repo;
+  $('pat').value = LS.pat;
+  if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
+  $('settings-btn').onclick = () => $('settings').classList.toggle('hidden');
+  $('save-settings').onclick = () => {
+    LS.repo = $('repo').value.trim();
+    LS.pat = $('pat').value.trim();
+    $('settings').classList.add('hidden');
+  };
+
+  // Toggle conditions
+  $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
+
+  $('dispatch').onclick = dispatch;
+  $('back').onclick = () => { stopPoll(); show('main'); renderHistory(); };
+
+  setupMic();
+  renderHistory();
+
+  if ('serviceWorker' in navigator) navigator.serviceWorker.register('sw.js').catch(() => {});
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/docs/pocket/icon.svg
+++ b/docs/pocket/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#0b0f17"/>
+  <circle cx="256" cy="256" r="150" fill="none" stroke="#6aa3ff" stroke-width="26"/>
+  <path d="M316 196a86 86 0 1 0 0 120" fill="none" stroke="#6aa3ff" stroke-width="26" stroke-linecap="round"/>
+  <circle cx="256" cy="256" r="26" fill="#6aa3ff"/>
+</svg>

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -40,6 +40,15 @@
       </div>
     </label>
 
+    <label>Workflow
+      <select id="workflow">
+        <option value="auto">auto (Dispatch détecte)</option>
+        <option value="repondre-collegue">répondre à un collègue</option>
+        <option value="enrichir-contact">enrichir un contact</option>
+        <option value="diagnostic-sequence">diagnostic de séquence</option>
+      </select>
+    </label>
+
     <div class="row">
       <label class="toggle">
         <input id="write-allowed" type="checkbox" />

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0b0f17" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <title>Claude Pocket</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="apple-touch-icon" href="icon.svg" />
+  <link rel="icon" href="icon.svg" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>📱 Claude Pocket</h1>
+    <button id="settings-btn" class="icon-btn" title="Réglages">⚙️</button>
+  </header>
+
+  <!-- Réglages -->
+  <section id="settings" class="card hidden">
+    <h2>Réglages</h2>
+    <label>Repo <small>(owner/nom)</small>
+      <input id="repo" type="text" placeholder="GaspardCoche/agent-system" autocapitalize="off" autocorrect="off" />
+    </label>
+    <label>GitHub PAT <small>(fine-grained — Issues RW + Actions RW)</small>
+      <input id="pat" type="password" placeholder="github_pat_…" autocapitalize="off" autocorrect="off" />
+    </label>
+    <button id="save-settings" class="primary">Enregistrer</button>
+    <p class="hint">Le token reste sur ton téléphone (localStorage). Voir <code>docs/pocket-setup.md</code>.</p>
+  </section>
+
+  <!-- Composer une demande -->
+  <section id="composer" class="card">
+    <label>Demande
+      <div class="textarea-wrap">
+        <textarea id="demande" rows="4" placeholder="Colle la question du collègue ou décris la tâche…"></textarea>
+        <button id="mic" class="icon-btn mic" title="Dicter">🎤</button>
+      </div>
+    </label>
+
+    <div class="row">
+      <label class="toggle">
+        <input id="write-allowed" type="checkbox" />
+        <span>Autoriser l'écriture</span>
+      </label>
+      <label class="agent-label">Agent
+        <select id="agent">
+          <option value="auto">auto</option>
+          <option value="crm (HubSpot / leads)">crm</option>
+          <option value="ads (Google Ads)">ads</option>
+          <option value="web (recherche / enrichissement)">web</option>
+          <option value="email">email</option>
+          <option value="code">code</option>
+        </select>
+      </label>
+    </div>
+
+    <label id="conditions-wrap" class="hidden">Conditions d'écriture
+      <textarea id="conditions" rows="3" placeholder="Ex : tu peux mettre lifecyclestage à 'lead', jamais l'écraser. Rien d'autre."></textarea>
+    </label>
+
+    <button id="dispatch" class="primary big">🚀 Dispatch</button>
+    <p id="composer-msg" class="msg"></p>
+  </section>
+
+  <!-- Historique -->
+  <section id="history" class="card">
+    <h2>Historique</h2>
+    <ul id="history-list"></ul>
+  </section>
+
+  <!-- Détail d'une tâche -->
+  <section id="detail" class="card hidden">
+    <button id="back" class="link-btn">← Retour</button>
+    <h2 id="detail-title">Tâche</h2>
+    <div id="detail-meta" class="meta"></div>
+    <div id="comments"></div>
+    <button id="approve" class="primary hidden">✅ Approuver l'écriture</button>
+    <p id="detail-msg" class="msg"></p>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/pocket/manifest.webmanifest
+++ b/docs/pocket/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "Claude Pocket",
+  "short_name": "Pocket",
+  "description": "Déclencher les agents Claude depuis le téléphone",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#0b0f17",
+  "theme_color": "#0b0f17",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -1,0 +1,114 @@
+:root {
+  --bg: #0b0f17;
+  --card: #131a26;
+  --card2: #1b2433;
+  --text: #e6edf3;
+  --muted: #8b97a8;
+  --accent: #6aa3ff;
+  --accent2: #3b6fd4;
+  --ok: #3fb950;
+  --warn: #d29922;
+  --border: #243044;
+  --radius: 14px;
+}
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  padding: env(safe-area-inset-top) 14px calc(env(safe-area-inset-bottom) + 24px);
+  max-width: 640px;
+  margin: 0 auto;
+}
+header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px 4px 12px;
+}
+h1 { font-size: 20px; margin: 0; }
+h2 { font-size: 15px; margin: 0 0 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 14px;
+}
+label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 12px; }
+label small { font-weight: 400; opacity: .7; }
+input[type=text], input[type=password], textarea, select {
+  width: 100%;
+  margin-top: 6px;
+  padding: 12px;
+  background: var(--card2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 16px; /* >=16px évite le zoom auto iOS */
+  font-family: inherit;
+}
+textarea { resize: vertical; }
+.textarea-wrap { position: relative; }
+.textarea-wrap .mic { position: absolute; right: 8px; bottom: 8px; }
+.row { display: flex; gap: 12px; align-items: center; justify-content: space-between; }
+.toggle { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.toggle input { width: 22px; height: 22px; }
+.toggle span { color: var(--text); }
+.agent-label { flex: 0 0 auto; }
+.agent-label select { width: auto; }
+button { cursor: pointer; font-family: inherit; }
+.primary {
+  width: 100%;
+  padding: 13px;
+  background: var(--accent2);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.primary:active { background: var(--accent); }
+.primary.big { padding: 16px; font-size: 17px; margin-top: 4px; }
+.icon-btn {
+  background: var(--card2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 18px;
+  width: 40px; height: 40px;
+}
+.icon-btn.mic.live { background: #5a1f1f; border-color: #c0392b; animation: pulse 1s infinite; }
+@keyframes pulse { 50% { opacity: .55; } }
+.link-btn { background: none; border: none; color: var(--accent); font-size: 14px; padding: 0 0 10px; }
+.hidden { display: none !important; }
+.hint { font-size: 12px; color: var(--muted); margin: 10px 0 0; }
+.msg { font-size: 13px; margin: 10px 0 0; min-height: 18px; }
+.msg.ok { color: var(--ok); }
+.msg.err { color: #f85149; }
+ul { list-style: none; padding: 0; margin: 0; }
+#history-list li {
+  padding: 12px;
+  background: var(--card2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 8px;
+  display: flex; justify-content: space-between; align-items: center; gap: 10px;
+}
+#history-list li .t { font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.badge { font-size: 11px; padding: 3px 8px; border-radius: 999px; white-space: nowrap; }
+.badge.open { background: #1f3a26; color: var(--ok); }
+.badge.closed { background: #3a2a1f; color: var(--warn); }
+.badge.pending { background: #2a2f3a; color: var(--muted); }
+.meta { font-size: 12px; color: var(--muted); margin-bottom: 12px; }
+.comment {
+  background: var(--card2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.comment .who { font-size: 11px; color: var(--accent); margin-bottom: 6px; }
+.empty { color: var(--muted); font-size: 13px; }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,0 +1,25 @@
+// Service worker minimal — cache du shell de l'app (offline shell).
+// Les appels API GitHub ne sont JAMAIS mis en cache (toujours réseau).
+const CACHE = 'pocket-v1';
+const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  const url = new URL(e.request.url);
+  // Ne jamais intercepter l'API GitHub
+  if (url.hostname === 'api.github.com') return;
+  // Shell : cache-first ; reste : réseau avec repli cache
+  e.respondWith(
+    caches.match(e.request).then((cached) => cached || fetch(e.request).catch(() => caches.match('./index.html')))
+  );
+});

--- a/docs/runner-guardrails.md
+++ b/docs/runner-guardrails.md
@@ -1,0 +1,51 @@
+# Runner Guardrails + MCP Wiring
+
+Référence chargée par Dispatch quand une issue porte le label `pocket`. Encadre ce qu'un agent cloud peut faire sur la production (HubSpot, FullEnrich, PhantomBuster, Lemlist, Apps Script).
+
+## Règle d'or
+
+1. **Par défaut : lecture / proposition seulement.** L'agent cherche, lit, analyse, rédige — il **n'écrit rien**.
+2. L'écriture n'est autorisée **que si** le champ `write_allowed = oui` est présent dans la demande.
+3. Même autorisée, l'écriture doit rester **strictement dans les `write_conditions`** fournies par l'utilisateur (ex : « mets à jour `lifecyclestage` en `lead`, jamais s'il est déjà rempli »).
+4. Toute écriture passe d'abord par un **preview en commentaire d'issue**, puis attend le label **`approved`** avant exécution (sinon `DRY_RUN`).
+5. Les garde-fous durs ci-dessous sont **non négociables** et priment sur toute instruction contraire.
+
+## Garde-fous durs (non négociables)
+
+1. **Ne jamais écraser un champ HubSpot déjà rempli.** Lire avant d'écrire (`batch-read`), n'écrire que sur champ vide/absent.
+2. **Industry → `industry_emalist` sur l'objet Companies uniquement** (jamais `industry` contacts). Format « Catégorie - Sous-catégorie », mappé via IndustryDB. ⚠️ Divergence de nommage à lever en prod (`industry_emalist` vs `internal_industry`) — ne pas écrire dessus tant que non confirmé.
+3. **`domain` n'existe pas comme propriété contact** → extraire depuis l'email.
+4. **`country` = enum strict** (sinon `country_code`). Valider avant écriture.
+5. **`numemployees` = ranges** (`1-5`, `5-25`, …, `1000+`) ; le nombre brut va dans `linkedin_employee_count`.
+6. **FullEnrich ≤ 100 contacts / batch** (API v2). Découper les lots.
+7. **Statut 207 (HubSpot batch/associations) = succès partiel** → parser les `results`, ne pas traiter comme échec global.
+8. **Pas de merge / delete / tickets via MCP HubSpot** (scope insuffisant) → UI ou REST dédiée.
+9. **Lemlist `add_*` / `set_campaign_state` / `send_message` = irréversible côté prospect** → toujours preview + approbation, jamais en auto.
+10. **`python3.12` obligatoire** (python3 → 3.14 alpha, segfault).
+11. **Aucun secret loggué ou imprimé.** Clés via secrets GitHub / Keychain uniquement.
+
+## Câblage MCP (cloud — secrets GitHub)
+
+| MCP / API | Type | Endpoint / commande | Secret GitHub |
+|---|---|---|---|
+| **hubspot** | MCP stdio | `npx @hubspot/mcp-server` (env `PRIVATE_APP_ACCESS_TOKEN`) | `HUBSPOT_PRIVATE_APP_TOKEN` |
+| **lemlist** | MCP http | `https://app.lemlist.com/mcp` (header `X-API-Key`) | `LEMLIST_API_KEY` |
+| **firecrawl** | MCP stdio | `npx firecrawl-mcp` | `FIRECRAWL_API_KEY` |
+| **github** | MCP stdio | `npx @modelcontextprotocol/server-github` | `GITHUB_TOKEN` (auto) |
+| **FullEnrich** | Python direct | API v2 bulk, ≤100/batch | `FULLENRICH_API_KEY` |
+| **PhantomBuster** | Python direct | `https://api.phantombuster.com/api/v2/` (header `X-Phantombuster-Key`) | `PHANTOMBUSTER_API_KEY` |
+| **Gemini** | env | grands fichiers (>50KB) | `GEMINI_API_KEY` |
+
+## Opérations lecture seule vs écriture
+
+| Outil | Lecture seule (auto) | Écriture (preview + `approved` + conditions) |
+|---|---|---|
+| **HubSpot** | `search-objects`, `list-objects`, `batch-read-objects`, `list/get-property`, `get-schemas`, `list-associations`, `list/get-workflow` | `batch-update-objects`, `batch-create-objects`, `batch-create-associations`, `create/update-property`, `create/update-engagement` (GF #1-8) |
+| **FullEnrich** | — | bulk enrich ≤100/batch → update HubSpot non destructif (GF #1,6) |
+| **PhantomBuster** | fetch results | lancer un agent / scraping |
+| **Lemlist** | `get_campaigns*`, `search_*`, `get_inbox_*`, `preview_*` | `add_leads_to_campaign`, `set_campaign_state`, `send_message`, séquences (GF #9) |
+| **Apps Script** | lecture déploiements | `clasp push` / deploy |
+
+## Comportement attendu si un secret manque
+
+Signaler proprement « secret `X` absent, action non exécutée » dans le commentaire ; **ne pas planter** ni exécuter partiellement.

--- a/docs/superpowers/plans/2026-06-16-claude-pocket.md
+++ b/docs/superpowers/plans/2026-06-16-claude-pocket.md
@@ -1,0 +1,242 @@
+# Claude Pocket Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Déclencher les agents cloud `agent-system` depuis une PWA iPhone, avec garde-fous d'écriture et auth résiliente au changement de plan SDK.
+
+**Architecture :** L'iPhone (PWA hébergée sur GitHub Pages) crée une issue GitHub labellisée `agent` via l'API REST. L'`orchestrator.yml` existant route vers l'agent spécialisé. Les écritures passent par le gate d'approbation existant (preview → label `approved`). Auth commutable abonnement↔API via un secret unique.
+
+**Tech Stack :** GitHub Actions (workflows existants), `anthropics/claude-code-action@v1`, HTML/CSS/JS vanilla (PWA, zéro build), GitHub REST API, GitHub Pages.
+
+**Repo :** `GaspardCoche/agent-system`, branche `claude-pocket`.
+
+---
+
+## File Structure
+
+| Fichier | Action | Responsabilité |
+|---|---|---|
+| `.github/workflows/_reusable-claude.yml` | Modify | Auth commutable (`anthropic_api_key`) + input `model` |
+| `docs/runner-guardrails.md` | Create | Référence garde-fous durs + câblage MCP (lecture/écriture) |
+| `.github/ISSUE_TEMPLATE/pocket-task.yml` | Create | Formulaire d'issue → corps structuré pour Dispatch |
+| `.github/ISSUE_TEMPLATE/config.yml` | Create | Désactive les issues blank, pointe vers le template |
+| `.mcp.json` | Modify | Ajout serveurs `hubspot`, `lemlist` (référence locale) |
+| `docs/pocket/index.html` | Create | Coquille PWA |
+| `docs/pocket/app.js` | Create | Logique : créer issue, poller, approuver, dictée |
+| `docs/pocket/style.css` | Create | Style mobile |
+| `docs/pocket/manifest.webmanifest` | Create | Installable écran d'accueil |
+| `docs/pocket/sw.js` | Create | Service worker minimal (shell offline) |
+| `docs/pocket/icon.svg` | Create | Icône |
+| `docs/pocket-setup.md` | Create | Guide : secrets GitHub à créer, PAT, install iPhone |
+
+---
+
+## Phase 0 — Socle auth & garde-fous
+
+### Task 1 : Auth commutable + routage modèle dans le reusable
+
+**Files:**
+- Modify: `.github/workflows/_reusable-claude.yml`
+
+- [ ] **Step 1 : Ajouter les inputs `model`**
+
+Dans le bloc `inputs:` (après `allowed_tools`), ajouter :
+
+```yaml
+      model:
+        required: false
+        type: string
+        default: "claude-haiku-4-5"
+```
+
+- [ ] **Step 2 : Pinner le modèle dans claude_args**
+
+Étape « Build claude_args », remplacer la ligne `echo "CLAUDE_ARGS=...` par :
+
+```bash
+          echo "CLAUDE_ARGS=--model ${{ inputs.model }} --max-turns ${{ inputs.max_turns }} --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
+```
+
+- [ ] **Step 3 : Ajouter l'auth commutable**
+
+Étape « Run Claude agent », sous `claude_code_oauth_token:`, ajouter :
+
+```yaml
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Secret vide = abonnement (0 €). Rempli = API métré. Aucun autre changement de code requis pour basculer.
+
+- [ ] **Step 4 : Valider la syntaxe YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_reusable-claude.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add .github/workflows/_reusable-claude.yml
+git commit -m "feat(pocket): switchable auth + pinned model in reusable workflow"
+```
+
+### Task 2 : Document de référence garde-fous
+
+**Files:**
+- Create: `docs/runner-guardrails.md`
+
+- [ ] **Step 1 : Écrire le doc** (contenu = garde-fous durs #1-10 du spec §4.3 + tableau MCP lecture/écriture §4.4, issu de la recherche vault). Inclure : règle d'or (lecture par défaut, écriture seulement si `write_allowed` + conditions + garde-fous), tableau MCP endpoint/secret, colonnes lecture-seule vs écriture par outil.
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/runner-guardrails.md
+git commit -m "docs(pocket): runner guardrails + MCP wiring reference"
+```
+
+---
+
+## Phase 1 — Entry point (issue → Dispatch)
+
+### Task 3 : Formulaire d'issue Pocket Task
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/pocket-task.yml`
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+
+- [ ] **Step 1 : Créer le formulaire** avec champs : `demande` (textarea, requis), `write_allowed` (dropdown oui/non, défaut non), `write_conditions` (textarea), `agent_hint` (dropdown : auto/crm/ads/web/email/code). Le template applique `labels: [agent, pocket]`.
+
+- [ ] **Step 2 : Créer config.yml** : `blank_issues_enabled: false`.
+
+- [ ] **Step 3 : Valider YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/pocket-task.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/
+git commit -m "feat(pocket): issue form entry point for mobile dispatch"
+```
+
+### Task 4 : Injecter garde-fous + conditions dans le prompt Dispatch
+
+**Files:**
+- Modify: `agent_prompts/dispatch.md` (ou créer si absent)
+
+- [ ] **Step 1 : Ajouter une section « Pocket / garde-fous »** au prompt Dispatch : si l'issue porte le label `pocket`, lire `docs/runner-guardrails.md` ; respecter la règle d'or ; si `write_allowed=non`, ne produire qu'une proposition ; si `write_allowed=oui`, préparer un preview et exiger le label `approved` avant toute écriture, en restant dans les `write_conditions`.
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add agent_prompts/dispatch.md
+git commit -m "feat(pocket): wire guardrails + write-conditions into dispatch prompt"
+```
+
+---
+
+## Phase 2 — Câblage MCP cloud
+
+### Task 5 : Ajouter HubSpot + Lemlist au reusable MCP config
+
+**Files:**
+- Modify: `.github/workflows/_reusable-claude.yml` (étape « Write MCP config with secrets »)
+- Modify: `.mcp.json` (référence locale)
+
+- [ ] **Step 1 : Ajouter les serveurs MCP** dans le `python3 -c` qui écrit `/tmp/mcp-config.json` : `hubspot` (npx `@hubspot/mcp-server`, env `PRIVATE_APP_ACCESS_TOKEN` ← `secrets.HUBSPOT_PRIVATE_APP_TOKEN`), `lemlist` (http `https://app.lemlist.com/mcp`, header `X-API-Key` ← `secrets.LEMLIST_API_KEY`). Ajouter les env correspondants à l'étape.
+
+- [ ] **Step 2 : Étendre la liste d'outils autorisés** : ajouter les outils HubSpot **lecture seule** au `BASE` (search/list/batch-read/get-property). Les outils d'écriture restent passés via `allowed_tools` par l'agent et gated par approbation.
+
+- [ ] **Step 3 : Documenter les secrets requis** dans `docs/pocket-setup.md` (Task 9).
+
+- [ ] **Step 4 : Valider YAML + commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_reusable-claude.yml'))" && echo OK
+git add .github/workflows/_reusable-claude.yml .mcp.json
+git commit -m "feat(pocket): wire HubSpot + Lemlist MCP via GitHub secrets"
+```
+
+---
+
+## Phase 3 — PWA iPhone
+
+### Task 6 : Coquille + manifest + service worker
+
+**Files:**
+- Create: `docs/pocket/index.html`, `docs/pocket/manifest.webmanifest`, `docs/pocket/sw.js`, `docs/pocket/icon.svg`, `docs/pocket/style.css`
+
+- [ ] **Step 1** : index.html (champ token GitHub, champ demande, dictée, toggle écriture + conditions, sélecteur agent, bouton Dispatch, zone historique/résultat). Lien manifest + enregistrement SW.
+- [ ] **Step 2** : manifest (name, icons, display standalone, theme color).
+- [ ] **Step 3** : sw.js (cache du shell : index/app/style/icon).
+- [ ] **Step 4** : style.css (mobile-first, dark).
+- [ ] **Step 5 : Commit**
+
+```bash
+git add docs/pocket/
+git commit -m "feat(pocket): PWA shell, manifest, service worker"
+```
+
+### Task 7 : Logique app.js
+
+**Files:**
+- Create: `docs/pocket/app.js`
+
+- [ ] **Step 1 : Stockage token** : PAT fine-grained en `localStorage` (clé `pocket_pat`, repo `pocket_repo`).
+- [ ] **Step 2 : Dispatch** : `POST /repos/{owner}/{repo}/issues` avec titre court + corps structuré (demande, write_allowed, write_conditions, agent_hint) + labels `[agent, pocket]`. Stocker le numéro d'issue dans l'historique.
+- [ ] **Step 3 : Polling** : `GET /repos/{owner}/{repo}/issues/{n}/comments` toutes les ~15 s, afficher les commentaires (preview/résultat).
+- [ ] **Step 4 : Approuver** : bouton qui `POST` le label `approved` sur l'issue.
+- [ ] **Step 5 : Dictée** : Web Speech API (`webkitSpeechRecognition`) sur le champ demande.
+- [ ] **Step 6 : Validation manuelle iOS Safari** (Task 10).
+- [ ] **Step 7 : Commit**
+
+```bash
+git add docs/pocket/app.js
+git commit -m "feat(pocket): app logic — create issue, poll, approve, voice"
+```
+
+### Task 8 : Déploiement Pages
+
+**Files:**
+- Modify: `.github/workflows/deploy-pages.yml` (vérifier que `docs/pocket/` est inclus — il l'est, path `docs`)
+
+- [ ] **Step 1** : Confirmer que `deploy-pages.yml` upload `docs/` (déjà le cas). Aucun changement si la PWA est sous `docs/pocket/`.
+- [ ] **Step 2** : Après merge sur `main`, vérifier l'URL `https://<user>.github.io/agent-system/pocket/`.
+
+---
+
+## Phase 4 — Setup & validation
+
+### Task 9 : Guide de setup
+
+**Files:**
+- Create: `docs/pocket-setup.md`
+
+- [ ] **Step 1 : Écrire le guide** : (a) liste exacte des secrets GitHub à créer (`HUBSPOT_PRIVATE_APP_TOKEN`, `FULLENRICH_API_KEY`, `PHANTOMBUSTER_API_KEY`, `LEMLIST_API_KEY`, `GEMINI_API_KEY`, `FIRECRAWL_API_KEY`, `ANTHROPIC_API_KEY` laissé vide) ; (b) création d'un PAT fine-grained (scope : Issues RW + Actions RW sur le seul repo) ; (c) activation GitHub Pages (branche/source) ; (d) install PWA sur iPhone (Safari → Partager → Sur l'écran d'accueil).
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/pocket-setup.md
+git commit -m "docs(pocket): setup guide (secrets, PAT, Pages, iPhone install)"
+```
+
+### Task 10 : Validation bout-en-bout (dry-run, sans clés)
+
+- [ ] **Step 1** : Créer une issue de test via le formulaire (`write_allowed=non`) → vérifier que `orchestrator.yml` se déclenche (Actions tab).
+- [ ] **Step 2** : Vérifier qu'un commentaire de planification est posté.
+- [ ] **Step 3** : Vérifier qu'aucune écriture externe n'a lieu (pas de clés CRM encore → l'agent doit signaler « secret absent » proprement, pas planter).
+- [ ] **Step 4** : Ouvrir la PWA sur iPhone, créer une demande, voir le commentaire remonter.
+
+---
+
+## Phase 5 — Workflows métier (itération suivante, hors MVP)
+
+3 recettes câblées comme prompts/skills : `répondre-collègue` (lecture HubSpot + rédaction), `enrichir-contact` (FullEnrich ≤100 + update non destructif), `diagnostic-séquence` (lecture séquences/engagements). Chacune = un fichier prompt + entrée dans le sélecteur agent de la PWA. À planifier séparément une fois le socle validé.
+
+---
+
+## Self-Review
+
+- **Spec coverage** : §4.1 PWA → Tasks 6-8 ; §4.2 entry point → Tasks 3-4 ; §4.3 garde-fous → Tasks 2,4 ; §4.4 MCP → Task 5 ; §4.5 limites/auth → Task 1 ; §8 coût → inchangé ; §9 phases → mappées. Workflows métier §11/Phase 5 explicitement hors MVP.
+- **Placeholders** : les contenus longs (guardrails, PWA, setup) sont décrits avec leur structure complète ; le code réel est écrit à l'exécution (plan exécuté inline par l'auteur, pas par un tiers sans contexte).
+- **Type consistency** : labels `agent`+`pocket` cohérents (Task 3 pose, Task 4/7 consomment) ; secret `ANTHROPIC_API_KEY` cohérent (Task 1 consomme, Task 9 documente) ; clés localStorage `pocket_pat`/`pocket_repo` cohérentes (Task 7).

--- a/docs/superpowers/specs/2026-06-16-claude-pocket-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-pocket-design.md
@@ -1,0 +1,170 @@
+# Claude Pocket — Design
+
+**Date :** 2026-06-16
+**Auteur :** Gaspard Coche (+ Claude)
+**Statut :** En attente de validation utilisateur
+**Repo cible :** `GaspardCoche/agent-system` (extension de l'infra existante)
+
+---
+
+## 1. Objectif
+
+Permettre à Gaspard de **déclencher Claude depuis son iPhone uniquement**, pour faire faire du travail métier (répondre aux questions des collègues posées sur Slack, agir sur HubSpot / FullEnrich / PhantomBuster / Google Apps Script via les MCP), pendant qu'il fait autre chose. Le système doit :
+
+- tourner **même Mac éteint** (exécution cloud) ;
+- rester **gratuit** dans sa configuration de base ;
+- être **résilient au changement de plan de la SDK Claude** (abonnement → API métré sans casse) ;
+- appliquer des **garde-fous durs** sur la production (CRM), avec écriture seulement sur autorisation explicite ;
+- réutiliser au maximum l'`agent-system` existant (orchestrateur multi-agents déjà en place).
+
+## 2. Insight fondateur
+
+`~/agent-system` est **déjà** un orchestrateur multi-agents tournant dans **GitHub Actions** :
+
+- agents spécialisés : Dispatch (orchestrateur), Scout (web/Firecrawl), Aria (leads/HubSpot/FullEnrich), Nexus (Google Ads), Iris (email), Sage (prompts), Forge (code), Sentinel (QA), Lumen (data/Gemini) ;
+- déclenchement par **issue labellisée `agent`** ou `workflow_dispatch` (input `task_description`) — cf. `orchestrator.yml` ;
+- **passerelle d'approbation** déjà construite : preview en commentaire d'issue → label `approved` pour exécuter, sinon `DRY_RUN` ;
+- **protocole de communication** JSON (`/tmp/agent_task.json` → `/tmp/agent_result.json` + champ `retrospective`) ;
+- **GitHub Pages** déjà déployable (`deploy-pages.yml`) → hébergement PWA gratuit ;
+- plan d'**auth commutable** déjà conçu (secret `ANTHROPIC_API_KEY` vide = abonnement OAuth gratuit, rempli = API métré) — cf. `_reusable-claude.yml`.
+
+**Conséquence :** l'iPhone ne pilote pas le Mac. Il **déclenche les agents cloud existants** et reçoit le résultat. On construit la *porte d'entrée mobile* + le *câblage MCP cloud* + la *couche d'autonomie/garde-fous*, on ne réécrit pas l'orchestrateur.
+
+## 3. Architecture
+
+```
+┌─────────────────────────────┐
+│  iPhone — PWA "Claude Pocket"│  (hébergée GitHub Pages, ajoutée écran d'accueil)
+│  • champ texte + dictée voix │
+│  • bouton "Dispatch"         │
+│  • toggle "Autoriser écriture"│
+│  • historique + push notifs  │
+└──────────────┬──────────────┘
+               │ GitHub REST API (fine-grained PAT, scope issues+actions)
+               ▼
+┌─────────────────────────────┐
+│  GitHub Issue (label "agent")│  ← thread = trace + canal d'approbation
+└──────────────┬──────────────┘
+               │ on: issues labeled
+               ▼
+┌─────────────────────────────┐
+│  orchestrator.yml — Dispatch │  décompose + route vers l'agent spécialisé
+│  (via _reusable-claude.yml)  │
+└──────────────┬──────────────┘
+               │ injecte garde-fous + conditions d'écriture parsées
+               ▼
+   ┌───────────────────────────┐
+   │  Agent spécialisé + MCP    │  HubSpot / FullEnrich / PhantomBuster / Lemlist / Apps Script
+   └───────────┬───────────────┘
+   LECTURE auto │ ÉCRITURE seulement si autorisée + dans les conditions
+               ▼
+┌─────────────────────────────┐
+│ Commentaire d'issue = preview│  → si écriture : attend label "approved"
+│ puis résultat final          │  → push notif GitHub sur l'iPhone
+└──────────────┬──────────────┘
+               │ la PWA poll l'issue (API) → affiche résultat + bouton "Approuver"
+               ▼
+        Gaspard copie la réponse → Slack au collègue
+```
+
+## 4. Composants (unités à frontières claires)
+
+### 4.1 PWA « Claude Pocket » (`pocket/` → GitHub Pages)
+- **Rôle :** unique interface mobile. Saisie (texte + dictée Web Speech API), déclenchement, suivi, approbation.
+- **Entrées :** texte de la demande, toggle « autoriser écriture » + zone « conditions d'écriture », sélection d'agent (auto par défaut).
+- **Dépendances :** GitHub REST API (création d'issue, lecture commentaires, ajout label `approved`). Auth via **PAT fine-grained** stocké en `localStorage` (usage perso mono-utilisateur).
+- **Sorties :** issue créée ; affichage du fil + résultat ; bouton « Approuver ».
+- **Tech :** HTML/CSS/JS vanilla (zéro build, sert tel quel sur Pages). PWA installable (manifest + service worker minimal pour l'icône/offline shell).
+
+### 4.2 Entry point agent (`.github/ISSUE_TEMPLATE/pocket-task.yml` + parsing)
+- **Rôle :** normaliser une demande venue du téléphone en `task.json` pour Dispatch.
+- **Champs structurés :** `demande`, `write_allowed` (bool), `write_conditions` (texte libre), `agent_hint` (optionnel).
+- **Dépendances :** `orchestrator.yml` (déjà déclenché par label `agent`).
+
+### 4.3 Couche d'autonomie & garde-fous (prompt système injecté)
+- **Rôle :** encadrer ce que l'agent peut écrire.
+- **Règle d'or :** par défaut **lecture/proposition seulement**. Écriture autorisée **uniquement si** `write_allowed=true`, et **strictement dans les `write_conditions`** fournies, **et** dans le respect des garde-fous durs ci-dessous.
+- **Garde-fous durs (non négociables, cf. `crm-context`) :**
+  1. Ne jamais écraser un champ HubSpot déjà rempli (lire avant d'écrire).
+  2. Industry → `industry_emalist` sur **Companies** uniquement (jamais `industry` contacts).
+  3. `country` = enum strict (sinon country_code).
+  4. `numemployees` = ranges ; nombre brut → `linkedin_employee_count`.
+  5. FullEnrich ≤ 100 contacts/batch.
+  6. Statut 207 = succès partiel → parser les `results`.
+  7. Pas de merge/delete/tickets via MCP HubSpot.
+  8. Lemlist `add_*/set_campaign_state/send_message` = irréversible côté prospect → **toujours preview + approbation**.
+  9. `python3.12` obligatoire.
+  10. Aucun secret loggué/imprimé.
+- **Mécanisme d'approbation :** toute écriture passe par un **preview en commentaire** ; exécution seulement après label `approved` (réutilise le gate existant). `DRY_RUN=true` tant que non approuvé.
+
+### 4.4 Câblage MCP cloud (`.mcp.json` + secrets GitHub)
+- **Rôle :** donner aux agents cloud l'accès aux outils, via secrets GitHub chiffrés.
+- **À ajouter en secrets** (clés fournies par Gaspard) : `HUBSPOT_PRIVATE_APP_TOKEN`, `FULLENRICH_API_KEY`, `PHANTOMBUSTER_API_KEY`, `LEMLIST_API_KEY`, (Apps Script : `CLASP_CREDENTIALS` / service account). `GITHUB_TOKEN`, `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, `GEMINI_API_KEY` : déjà présents ou à confirmer.
+- **MCP serveurs** (ajouts au `.mcp.json` du repo) : `hubspot` (stdio, `PRIVATE_APP_ACCESS_TOKEN`), `lemlist` (http, header `X-API-Key`), + FullEnrich/PhantomBuster en Python direct (skills validés).
+- **Lecture seule vs écriture :** tableau de référence dans `docs/runner-guardrails.md` (généré depuis la recherche vault).
+
+### 4.5 Limites, sécurité & résilience SDK
+- **`max_turns`** plafonné par complexité (3 simple / 8 moyen / 12 complexe — déjà dans `CLAUDE.md`).
+- **Budget mensuel** : compteur de runs + alerte ; minutes GitHub free tier (2000/mois) surveillées par `health-check.yml`.
+- **Auth commutable (résilience plan SDK)** : dans `_reusable-claude.yml`, ajouter `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` à côté de `claude_code_oauth_token`. Secret vide = abonnement (0 €). Le jour où l'abonnement Claude Code change de modèle de facturation, **remplir un seul secret** suffit à basculer sur l'API métré, sans modifier le code. Variante cloud : `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX`.
+- **Pinner le modèle** explicitement (`--model`) pour ne pas dépendre du défaut (défaut Haiku pour les agents simples, Sonnet/Opus selon rôle).
+- **Sécurité PAT PWA** : fine-grained, scope minimal (issues + actions read/write sur le seul repo `agent-system`), expirable, révocable. Stocké localStorage (acceptable mono-utilisateur ; documenté comme tel).
+
+## 5. Flux de données (exemple « répondre à un collègue »)
+
+1. Collègue sur Slack : « Pourquoi le contact X n'apparaît pas dans la séquence ? »
+2. Gaspard ouvre la PWA, dicte la question, **laisse le toggle écriture OFF**, tape « Dispatch ».
+3. PWA crée une issue `agent` avec le `task.json`.
+4. Dispatch route vers l'agent CRM → MCP HubSpot **en lecture** → analyse.
+5. Résultat posté en commentaire (diagnostic + réponse prête à copier). Push notif iPhone.
+6. Gaspard copie la réponse → Slack. Fin. (Aucune écriture, donc aucune approbation requise.)
+
+Variante avec écriture : Gaspard active le toggle + condition « tu peux mettre à jour le champ `lifecyclestage` en `lead`, jamais l'écraser s'il est déjà rempli ». L'agent prépare le preview → push notif → Gaspard tape « Approuver » → exécution dans les conditions.
+
+## 6. Gestion d'erreurs
+
+- Agent échoue → statut `failed` + `retry_reason` dans le commentaire ; self-correction max 3 cycles (déjà dans `CLAUDE.md`).
+- MCP indisponible / clé manquante → message explicite « secret X absent », pas d'exécution partielle silencieuse.
+- 207 HubSpot → traité comme succès partiel, détail par `result`.
+- Timeout GitHub Actions → notif d'échec, la file n'est pas bloquée (issues indépendantes).
+- PWA hors-ligne → shell affiché, file d'envoi mise en attente jusqu'au réseau.
+
+## 7. Tests
+
+- **Garde-fous :** test « tentative d'écraser un champ rempli » → doit refuser. Test « écriture sans autorisation » → doit rester en proposition.
+- **Auth commutable :** run avec `ANTHROPIC_API_KEY` vide (OAuth) puis rempli (API) → même comportement.
+- **Bout-en-bout dry-run :** issue de test → preview généré, pas d'écriture tant que `approved` absent.
+- **PWA :** création d'issue, lecture du fil, ajout label depuis le téléphone (Safari iOS).
+- `agent-tester.yml` / `Sentinel` réutilisés pour la validation.
+
+## 8. Coût
+
+| Poste | Coût | Note |
+|---|---|---|
+| Compute Claude | **0 €** | abonnement OAuth, pas de tokens métrés |
+| GitHub Actions | **0 €** | 2000 min/mois gratuits (repo privé) ; au-delà ~0,007 €/min |
+| GitHub Pages (PWA) | **0 €** | hébergement statique gratuit |
+| APIs data (FullEnrich, PhantomBuster…) | inchangé | abonnements existants, à l'usage |
+| **TOTAL système** | **≈ 0 €/mois** | hors dépassement éventuel de minutes |
+
+## 9. Phases de construction
+
+- **Phase 0 — Socle auth & garde-fous :** auth commutable dans `_reusable-claude.yml` ; `docs/runner-guardrails.md` ; pinning modèle.
+- **Phase 1 — Entry point :** template d'issue `pocket-task` + parsing → `task.json` ; vérifier le routage Dispatch.
+- **Phase 2 — Câblage MCP cloud :** ajout serveurs `.mcp.json` + secrets (clés fournies par Gaspard) ; test lecture HubSpot bout-en-bout.
+- **Phase 3 — PWA :** UI dispatch + dictée + historique + bouton approuver ; déploiement Pages ; install écran d'accueil.
+- **Phase 4 — Limites & observabilité :** budget/minutes, `retrospective` enrichie (model, tokens), alertes.
+- **Phase 5 — Workflows métier :** 2-3 recettes câblées (répondre-collègue, enrichir-contact, diagnostic-séquence).
+
+## 10. Points ouverts / à confirmer
+
+- Liste exacte des secrets API à fournir (Phase 2).
+- Nom exact du champ industry company en prod (`industry_emalist` vs `internal_industry`) — ne pas écrire dessus tant que non confirmé.
+- Repo privé conservé (2000 min) vs runner self-hosted plus tard si volume.
+- Décision modèle Iris-digest (Sonnet vs Opus) — hors périmètre direct mais lié au routage.
+
+## 11. Hors périmètre (YAGNI au démarrage)
+
+- App native iOS (Swift/App Store).
+- Runner self-hosted / Tailscale (gardé en évolution si dépassement minutes).
+- Session conversationnelle persistante (architecture C complète) — on démarre en jobs one-shot tracés par issue, le fil d'issue donne déjà le suivi.


### PR DESCRIPTION
## Claude Pocket
PWA iPhone → issue GitHub → agents cloud `agent-system`, avec garde-fous d'écriture et auth résiliente au changement de plan SDK.

### Contenu
- **Phase 0** : auth commutable (`ANTHROPIC_API_KEY` vide=abonnement) + modèle pinné · `docs/runner-guardrails.md`
- **Phase 1** : issue-form `pocket-task` + protocole garde-fous dans `dispatch.md`
- **Phase 2** : MCP HubSpot + Lemlist via secrets GitHub (lecture seule auto-autorisée)
- **Phase 3** : PWA (`docs/pocket/`) — dictée, dispatch, historique, approbation
- **Phase 4** : `docs/pocket-setup.md`
- **Phase 5** : 3 workflows métier (`repondre-collegue`, `enrichir-contact`, `diagnostic-sequence`)

Spec : `docs/superpowers/specs/2026-06-16-claude-pocket-design.md` · Plan : `docs/superpowers/plans/2026-06-16-claude-pocket.md`

Coût ≈ 0 €/mois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an iPhone-focused Claude Pocket workflow that triggers existing cloud agents from GitHub issues with strong write guardrails and switchable authentication, plus HubSpot/Lemlist MCP wiring and a mobile PWA front-end.

New Features:
- Introduce a Pocket issue mode in the dispatch prompt with structured parsing, write approval rules, and optional business workflows.
- Add a Claude Pocket PWA (HTML/JS/CSS, manifest, service worker) that lets an iPhone create agent issues, follow results, and approve writes via GitHub API.
- Provide dedicated workflow playbooks for responding to colleagues, enriching contacts, and diagnosing HubSpot sequences.

Enhancements:
- Extend the reusable Claude GitHub Action with a configurable model input, switchable Anthropic auth, and pre-wired read-only HubSpot and Lemlist MCP tools.
- Document runner guardrails and MCP wiring for safe CRM/email automation and add a detailed Claude Pocket design and implementation plan.
- Tighten issue intake via a Pocket task issue template and configuration to enforce structured mobile-triggered tasks.

Build:
- Update MCP config generation in the reusable workflow to conditionally register HubSpot and Lemlist servers and pass the selected model flag to claude-code.

Documentation:
- Add Claude Pocket design, implementation plan, runner guardrails, and a step-by-step setup guide including secrets, PAT creation, and PWA installation instructions.