### PR TITLE
fix(pocket): dedupe orchestrator trigger

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -31,8 +31,12 @@ jobs:
           if [[ "$EVENT" == "workflow_dispatch" || "$EVENT" == "schedule" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           elif [[ "$EVENT" == "issues" ]]; then
+            # Anti-doublon : une issue créée avec [agent, pocket] émet un event `labeled`
+            # PAR label. On ne déclenche que sur l'ajout du label `agent` (ou `approved`
+            # pour relancer après approbation d'écriture), pas sur `pocket`.
             LABELS='${{ toJSON(github.event.issue.labels.*.name) }}'
-            if echo "$LABELS" | grep -q '"agent"'; then
+            TRIGGER_LABEL="${{ github.event.label.name }}"
+            if echo "$LABELS" | grep -q '"agent"' && { [[ "$TRIGGER_LABEL" == "agent" ]] || [[ "$TRIGGER_LABEL" == "approved" ]]; }; then
               echo "should_run=true" >> $GITHUB_OUTPUT
             else
               echo "should_run=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Anti-doublon : une issue créée avec [agent, pocket] déclenchait l'orchestrateur 2× (un event `labeled` par label). On ne déclenche plus que sur l'ajout du label `agent` (ou `approved` pour relancer après approbation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the orchestrator workflow only triggers on the addition of the `agent` label (or `approved` for re-runs) instead of any Pocket-related label event.