### PR TITLE
fix(pocket): Dispatch HubSpot/Lemlist read tools

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -93,7 +93,8 @@ jobs:
         run: |
           npm install -g \
             @modelcontextprotocol/server-github \
-            @modelcontextprotocol/server-memory
+            @modelcontextprotocol/server-memory \
+            @hubspot/mcp-server
 
       - name: Write task
         env:
@@ -103,6 +104,8 @@ jobs:
       - name: Write MCP config
         env:
           GH_TOKEN_MCP: ${{ secrets.GITHUB_TOKEN }}
+          HUBSPOT_TOKEN_MCP: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
+          LEMLIST_KEY_MCP: ${{ secrets.LEMLIST_API_KEY }}
         run: |
           python3 -c "
           import json, os
@@ -110,12 +113,19 @@ jobs:
             'github': {'command': 'npx', 'args': ['-y', '@modelcontextprotocol/server-github'], 'env': {'GITHUB_PERSONAL_ACCESS_TOKEN': os.environ['GH_TOKEN_MCP']}},
             'memory': {'command': 'npx', 'args': ['-y', '@modelcontextprotocol/server-memory'], 'env': {}}
           }}
+          if os.environ.get('HUBSPOT_TOKEN_MCP'):
+              cfg['mcpServers']['hubspot'] = {'command': 'npx', 'args': ['-y', '@hubspot/mcp-server'], 'env': {'PRIVATE_APP_ACCESS_TOKEN': os.environ['HUBSPOT_TOKEN_MCP']}}
+          if os.environ.get('LEMLIST_KEY_MCP'):
+              cfg['mcpServers']['lemlist'] = {'type': 'http', 'url': 'https://app.lemlist.com/mcp', 'headers': {'X-API-Key': os.environ['LEMLIST_KEY_MCP']}}
           json.dump(cfg, open('/tmp/mcp-config.json', 'w'))
           "
 
       - name: Build claude_args
         run: |
-          echo "CLAUDE_ARGS=--max-turns 8 --allowedTools Bash,Read,Write,mcp__github__add_issue_comment,mcp__memory__add_observations --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
+          # Dispatch peut répondre directement aux questions de LECTURE (HubSpot/Lemlist) sans
+          # déléguer à un second job. Les écritures restent gérées par le workflow réutilisable + approbation.
+          READONLY="mcp__hubspot__hubspot-search-objects,mcp__hubspot__hubspot-list-objects,mcp__hubspot__hubspot-batch-read-objects,mcp__hubspot__hubspot-list-properties,mcp__hubspot__hubspot-get-property,mcp__hubspot__hubspot-get-schemas,mcp__hubspot__hubspot-list-associations,mcp__hubspot__hubspot-list-workflows,mcp__hubspot__hubspot-get-workflow,mcp__lemlist__get_campaigns,mcp__lemlist__get_campaign_details,mcp__lemlist__get_campaigns_stats,mcp__lemlist__search_contacts,mcp__lemlist__get_inbox_conversations"
+          echo "CLAUDE_ARGS=--max-turns 8 --allowedTools Bash,Read,Write,mcp__github__add_issue_comment,mcp__memory__add_observations,$READONLY --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
 
       - name: Run orchestrator (Claude)
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Le test e2e (#83) a montré que le job orchestrateur n'avait pas les outils HubSpot dans ses allowedTools ni le MCP HubSpot configuré. Dispatch peut désormais répondre directement aux questions de lecture CRM. Écritures toujours via le réutilisable + approbation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable the orchestrator job to use HubSpot and Lemlist MCP servers for direct read-only CRM queries while keeping write operations in the existing reusable workflow with approval.

New Features:
- Add HubSpot MCP server installation and configuration to the orchestrator workflow when a HubSpot token is provided.
- Add Lemlist MCP HTTP server configuration to the orchestrator workflow when a Lemlist API key is available.
- Expose selected read-only HubSpot and Lemlist MCP tools to the orchestrator via CLAUDE_ARGS allowedTools.