### PR TITLE
fix(pocket): MCP token env resolution

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -140,6 +140,10 @@ jobs:
             {
               "env": {
                 "GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
-                "GITHUB_REPOSITORY": "${{ github.repository }}"
+                "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+                "GITHUB_REPOSITORY": "${{ github.repository }}",
+                "HUBSPOT_PRIVATE_APP_TOKEN": "${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}",
+                "LEMLIST_API_KEY": "${{ secrets.LEMLIST_API_KEY }}",
+                "FIRECRAWL_API_KEY": "${{ secrets.FIRECRAWL_API_KEY }}"
               }
             }


### PR DESCRIPTION
Root cause du 401 : le .mcp.json du repo (chargé par claude-code-action) lit les tokens depuis l'env, non exportés. Fix : export dans settings.env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Export GitHub, HubSpot, Lemlist, and Firecrawl secrets as environment variables in the Pocket GitHub Actions workflow for MCP usage.