### PR TITLE
feat(pocket): FullEnrich + PhantomBuster deterministic scripts

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -139,6 +139,8 @@ jobs:
                  `python3 scripts/pocket_hubspot.py search contacts <prop> <valeur> --limit 5 --props email,firstname,lastname`
                  `python3 scripts/pocket_hubspot.py read contacts <id> --props email,lifecyclestage`
                  `python3 scripts/pocket_hubspot.py whoami` (test d'auth). N'utilise les outils MCP HubSpot qu'en complément.
+               - **Pour FullEnrich** (enrichissement) : `python3 scripts/pocket_fullenrich.py` — `status <id>` (lecture), `enrich-one --firstname F --lastname L --domain D [--linkedin URL] [--phones] [--hubspot-id ID]` ou `submit --file contacts.json`. Sans `--confirm` = dry-run (aucun crédit). N'ajoute `--confirm` QUE si `approved` = true.
+               - **Pour PhantomBuster** : `python3 scripts/pocket_phantombuster.py` — `agents`, `agent <id>`, `containers <agentId>`, `output <cId>`, `result <cId>` (lecture) ; `launch <agentId> [--argument-file f.json] --confirm` (scraping réel, seulement si `approved`).
                - Par défaut LECTURE seule (HubSpot/Lemlist) — tu cherches, lis, analyses.
                - ÉCRITURE autorisée UNIQUEMENT si `approved` = true ET "Autoriser l'écriture = oui" ET dans les Conditions ET les garde-fous durs. Si "Autoriser l'écriture = oui" mais `approved` = false, poste un PREVIEW de ce que tu ferais et demande l'approbation (label `approved`), n'écris rien.
                - Si un secret manque (ex : Lemlist), dis-le proprement, ne plante pas.

--- a/agent_prompts/workflows/enrichir-contact.md
+++ b/agent_prompts/workflows/enrichir-contact.md
@@ -11,9 +11,12 @@ Le champ `Demande` désigne la cible : un email/nom, une liste, ou un segment Hu
 ## Étapes
 1. **Garde-fous** : `cat docs/runner-guardrails.md` + `cat ~/crm-context/icp_and_data_rules.md` si présent (sinon vault).
 2. **Lire l'existant** (HubSpot, lecture) : `hubspot-search-objects` / `hubspot-batch-read-objects` → repérer **les champs VIDES** à compléter (GF #1 : ne jamais écraser un champ rempli).
-3. **Enrichir via FullEnrich** (Python direct, API v2) :
-   - Par lots de **≤ 100 contacts** (GF #6).
-   - Téléphone : ne garder que le **mobile** (politique FullEnrich vault).
+3. **Enrichir via FullEnrich** (script déterministe, API v2) :
+   - `python3 scripts/pocket_fullenrich.py enrich-one --firstname F --lastname L --domain D [--linkedin URL] [--phones] [--hubspot-id ID]` (un contact) ou `submit --file contacts.json` (lot).
+   - **Sans `--confirm` = dry-run** (aucun crédit). Ajoute `--confirm` UNIQUEMENT si `approved` = true.
+   - `--phones` seulement si le mobile est réellement manquant (coûte plus cher).
+   - Puis `status <enrichment_id>` pour récupérer les résultats (flux async, statut `FINISHED`).
+   - Par lots de **≤ 100 contacts** (GF #6). Employment : filtrer `is_current=true`. Pas de match ≠ erreur.
 4. **Mapper vers HubSpot** :
    - Industry → `industry_emalist` sur **Companies** (format « Catégorie - Sous-catégorie », mapping IndustryDB). ⚠️ ne pas écrire si nom de champ non confirmé en prod.
    - `numemployees` = range ; nombre brut → `linkedin_employee_count`.

--- a/docs/runner-guardrails.md
+++ b/docs/runner-guardrails.md
@@ -36,6 +36,18 @@ Référence chargée par Dispatch quand une issue porte le label `pocket`. Encad
 | **PhantomBuster** | Python direct | `https://api.phantombuster.com/api/v2/` (header `X-Phantombuster-Key`) | `PHANTOMBUSTER_API_KEY` |
 | **Gemini** | env | grands fichiers (>50KB) | `GEMINI_API_KEY` |
 
+## Scripts déterministes (voie privilégiée)
+
+Le MCP dans `claude-code-action` a un plumbing d'env fragile (token vide → 401). Pour HubSpot/FullEnrich/PhantomBuster, **préférer les scripts** (REST direct, stdlib, token via env du step), appelés par Bash :
+
+| Outil | Script | Lecture | Écriture / coût (gate `--confirm` + `approved`) |
+|---|---|---|---|
+| HubSpot | `scripts/pocket_hubspot.py` | `count`, `search`, `read`, `whoami` | — (les écritures HubSpot passent encore par MCP gated) |
+| FullEnrich | `scripts/pocket_fullenrich.py` | `status <id>` | `enrich-one` / `submit` (consomme des crédits → `--confirm`) |
+| PhantomBuster | `scripts/pocket_phantombuster.py` | `agents`, `agent`, `containers`, `output`, `result` | `launch` (scraping réel → `--confirm`) |
+
+`--confirm` n'est ajouté QUE si le label `approved` est présent.
+
 ## Opérations lecture seule vs écriture
 
 | Outil | Lecture seule (auto) | Écriture (preview + `approved` + conditions) |

--- a/scripts/pocket_fullenrich.py
+++ b/scripts/pocket_fullenrich.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3.12
+"""Outil FullEnrich déterministe pour Claude Pocket (API v2, flux bulk async).
+
+Token : env FULLENRICH_API_KEY (Bearer).
+LECTURE (status) libre. SOUMISSION (submit/enrich-one) consomme des crédits →
+exige --confirm (le runner/l'agent ne l'ajoute qu'après approbation `approved`).
+
+Usage :
+  pocket_fullenrich.py status <enrichment_id>
+  pocket_fullenrich.py enrich-one --firstname F --lastname L --domain D
+        [--linkedin URL] [--phones] [--hubspot-id ID] --confirm
+  pocket_fullenrich.py submit --file contacts.json [--name NAME] [--phones] --confirm
+      (contacts.json = liste de dicts : firstname,lastname,domain|company_name,linkedin_url,custom)
+
+Garde-fous : max 100/batch ; `contact_info.phones` seulement avec --phones
+(coûte plus cher) ; minimum par contact = (firstname+lastname+domain) OU linkedin_url.
+"""
+import sys, os, json, argparse, urllib.request, urllib.error
+
+BASE = "https://app.fullenrich.com/api/v2"
+
+
+def _hdrs():
+    t = os.environ.get("FULLENRICH_API_KEY", "").strip()
+    if not t:
+        print(json.dumps({"error": "FULLENRICH_API_KEY absent de l'environnement"}))
+        sys.exit(2)
+    return {"Authorization": f"Bearer {t}", "Content-Type": "application/json"}
+
+
+def _req(method, path, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method, headers=_hdrs())
+    try:
+        with urllib.request.urlopen(req, timeout=40) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            body = json.loads(body)
+        except Exception:
+            pass
+        return e.code, {"http_error": e.code, "body": body}
+
+
+def _enrich_fields(phones):
+    fields = ["contact_info.emails"]
+    if phones:
+        fields.append("contact_info.phones")
+    return fields
+
+
+def _validate(contacts):
+    for i, c in enumerate(contacts):
+        has_name = c.get("firstname") and c.get("lastname") and (c.get("domain") or c.get("company_name"))
+        if not (has_name or c.get("linkedin_url")):
+            return f"contact #{i} invalide : il faut (firstname+lastname+domain/company_name) OU linkedin_url"
+    if len(contacts) > 100:
+        return f"{len(contacts)} contacts > 100 max par batch"
+    return None
+
+
+def cmd_status(a):
+    status, body = _req("GET", f"/contact/enrich/bulk/{a.enrichment_id}")
+    return body
+
+
+def cmd_submit(a, contacts=None, name=None):
+    if contacts is None:
+        contacts = json.load(open(a.file))
+    err = _validate(contacts)
+    if err:
+        return {"error": err}
+    if not a.confirm:
+        return {"dry_run": True, "would_submit": len(contacts), "phones": bool(a.phones),
+                "note": "Action consommant des crédits — relancer avec --confirm (après approbation)."}
+    fields = _enrich_fields(a.phones)
+    for c in contacts:
+        c.setdefault("enrich_fields", fields)
+    payload = {"name": name or getattr(a, "name", None) or "pocket-batch", "datas": contacts}
+    status, body = _req("POST", "/contact/enrich/bulk", payload)
+    return body
+
+
+def cmd_enrich_one(a):
+    c = {"firstname": a.firstname, "lastname": a.lastname}
+    if a.domain:
+        c["domain"] = a.domain
+    if a.linkedin:
+        c["linkedin_url"] = a.linkedin
+    if a.hubspot_id:
+        c["custom"] = {"hubspot_contact_id": a.hubspot_id}
+    return cmd_submit(a, contacts=[c], name=f"pocket-{a.lastname}")
+
+
+def main():
+    p = argparse.ArgumentParser(prog="pocket_fullenrich")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("status"); s.add_argument("enrichment_id"); s.set_defaults(fn=cmd_status)
+
+    e = sub.add_parser("enrich-one")
+    e.add_argument("--firstname", required=True); e.add_argument("--lastname", required=True)
+    e.add_argument("--domain", default=""); e.add_argument("--linkedin", default="")
+    e.add_argument("--hubspot-id", dest="hubspot_id", default="")
+    e.add_argument("--phones", action="store_true"); e.add_argument("--confirm", action="store_true")
+    e.set_defaults(fn=cmd_enrich_one)
+
+    b = sub.add_parser("submit")
+    b.add_argument("--file", required=True); b.add_argument("--name", default="")
+    b.add_argument("--phones", action="store_true"); b.add_argument("--confirm", action="store_true")
+    b.set_defaults(fn=cmd_submit)
+
+    a = p.parse_args()
+    print(json.dumps(a.fn(a), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pocket_phantombuster.py
+++ b/scripts/pocket_phantombuster.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3.12
+"""Outil PhantomBuster déterministe pour Claude Pocket (API v2).
+
+Token : env PHANTOMBUSTER_API_KEY (header X-Phantombuster-Key).
+LECTURE (agents/agent/containers/output/result) libre.
+LANCEMENT (launch) = scraping réel → exige --confirm (après approbation `approved`).
+
+Usage :
+  pocket_phantombuster.py agents                      # liste les phantoms
+  pocket_phantombuster.py agent <agentId>             # détail d'un phantom
+  pocket_phantombuster.py containers <agentId>        # exécutions d'un phantom
+  pocket_phantombuster.py output <containerId>        # logs d'une exécution
+  pocket_phantombuster.py result <containerId>        # résultat JSON d'une exécution
+  pocket_phantombuster.py launch <agentId> [--argument-file args.json] --confirm
+"""
+import sys, os, json, argparse, urllib.request, urllib.error, urllib.parse
+
+BASE = "https://api.phantombuster.com/api/v2"
+
+
+def _hdrs():
+    t = os.environ.get("PHANTOMBUSTER_API_KEY", "").strip()
+    if not t:
+        print(json.dumps({"error": "PHANTOMBUSTER_API_KEY absent de l'environnement"}))
+        sys.exit(2)
+    return {"X-Phantombuster-Key": t, "Content-Type": "application/json"}
+
+
+def _req(method, path, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(f"{BASE}/{path}", data=data, method=method, headers=_hdrs())
+    try:
+        with urllib.request.urlopen(req, timeout=40) as r:
+            txt = r.read().decode()
+            try:
+                return r.status, json.loads(txt or "{}")
+            except Exception:
+                return r.status, {"raw": txt[:4000]}
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            body = json.loads(body)
+        except Exception:
+            pass
+        return e.code, {"http_error": e.code, "body": body}
+
+
+def cmd_agents(a):
+    return _req("GET", "agents/fetch-all")[1]
+
+
+def cmd_agent(a):
+    return _req("GET", f"agents/fetch?id={urllib.parse.quote(a.agentId)}")[1]
+
+
+def cmd_containers(a):
+    return _req("GET", f"containers/fetch-all?agentId={urllib.parse.quote(a.agentId)}")[1]
+
+
+def cmd_output(a):
+    return _req("GET", f"containers/fetch-output?id={urllib.parse.quote(a.containerId)}")[1]
+
+
+def cmd_result(a):
+    return _req("GET", f"containers/fetch-result-object?id={urllib.parse.quote(a.containerId)}")[1]
+
+
+def cmd_launch(a):
+    if not a.confirm:
+        return {"dry_run": True, "would_launch_agent": a.agentId,
+                "note": "Scraping réel — relancer avec --confirm (après approbation)."}
+    payload = {"id": a.agentId}
+    if a.argument_file:
+        payload["argument"] = json.load(open(a.argument_file))
+    return _req("POST", "agents/launch", payload)[1]
+
+
+def main():
+    p = argparse.ArgumentParser(prog="pocket_phantombuster")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("agents").set_defaults(fn=cmd_agents)
+    g = sub.add_parser("agent"); g.add_argument("agentId"); g.set_defaults(fn=cmd_agent)
+    c = sub.add_parser("containers"); c.add_argument("agentId"); c.set_defaults(fn=cmd_containers)
+    o = sub.add_parser("output"); o.add_argument("containerId"); o.set_defaults(fn=cmd_output)
+    r = sub.add_parser("result"); r.add_argument("containerId"); r.set_defaults(fn=cmd_result)
+    l = sub.add_parser("launch"); l.add_argument("agentId"); l.add_argument("--argument-file", dest="argument_file", default=""); l.add_argument("--confirm", action="store_true"); l.set_defaults(fn=cmd_launch)
+
+    a = p.parse_args()
+    print(json.dumps(a.fn(a), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Même pattern que pocket_hubspot.py. Lectures libres, actions coûteuses gated par --confirm (ajouté seulement si label approved). Testés en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add deterministic CLI scripts for FullEnrich and PhantomBuster and wire them into Pocket workflows as the preferred path for enrichment and scraping operations.

New Features:
- Introduce a deterministic FullEnrich Python script supporting async bulk enrichment, single-contact enrichment, and status retrieval with dry-run support.
- Add a deterministic PhantomBuster Python script for listing agents, inspecting runs, fetching results, and launching scrapes with dry-run gating.

Enhancements:
- Document deterministic script usage for HubSpot, FullEnrich, and PhantomBuster as the preferred approach in runner guardrails and Pocket workflow prompts.
- Update the Pocket GitHub Actions workflow instructions to guide agents toward the new FullEnrich and PhantomBuster scripts with confirm-based gating on costly operations.

Documentation:
- Expand runner guardrails and enrichment workflow documentation to describe deterministic scripts, dry-run behavior, and approval requirements for credit-consuming or scraping actions.