### PR TITLE
feat(pocket): install UX — prefill repo + connection test

### DIFF
--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -202,15 +202,23 @@ function escapeHtml(s) {
 
 // ── Init ─────────────────────────────────────────────────────────────────
 function init() {
-  // Réglages
-  $('repo').value = LS.repo;
+  // Réglages — repo pré-rempli par défaut
+  $('repo').value = LS.repo || 'GaspardCoche/agent-system';
   $('pat').value = LS.pat;
   if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
   $('settings-btn').onclick = () => $('settings').classList.toggle('hidden');
-  $('save-settings').onclick = () => {
+  $('save-settings').onclick = async () => {
     LS.repo = $('repo').value.trim();
     LS.pat = $('pat').value.trim();
-    $('settings').classList.add('hidden');
+    const m = $('settings-msg');
+    m.className = 'msg'; m.textContent = '⏳ Test de connexion…';
+    try {
+      const r = await gh(''); // GET /repos/{owner}/{repo}
+      m.className = 'msg ok'; m.textContent = `✅ Connecté à ${r.full_name}`;
+      setTimeout(() => $('settings').classList.add('hidden'), 1200);
+    } catch (e) {
+      m.className = 'msg err'; m.textContent = '❌ ' + e.message + ' — vérifie le repo et le token (scopes Issues + Actions).';
+    }
   };
 
   // Toggle conditions

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -27,7 +27,8 @@
     <label>GitHub PAT <small>(fine-grained — Issues RW + Actions RW)</small>
       <input id="pat" type="password" placeholder="github_pat_…" autocapitalize="off" autocorrect="off" />
     </label>
-    <button id="save-settings" class="primary">Enregistrer</button>
+    <button id="save-settings" class="primary">Enregistrer & tester</button>
+    <p id="settings-msg" class="msg"></p>
     <p class="hint">Le token reste sur ton téléphone (localStorage). Voir <code>docs/pocket-setup.md</code>.</p>
   </section>
 


### PR DESCRIPTION
Pré-remplit le repo et teste la connexion GitHub au save. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prefill the GitHub repository setting by default and validate the GitHub connection when saving settings in the Pocket UI.

New Features:
- Prefill the repository input with a default GitHub repo when no value is stored.
- Add an inline GitHub connection test when saving settings, with success and error feedback messages in the UI.