### PR TITLE
feat(pocket): Opus 4.8

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -111,7 +111,7 @@ jobs:
             WRITE="mcp__hubspot__hubspot-batch-update-objects,mcp__hubspot__hubspot-batch-create-objects,mcp__hubspot__hubspot-batch-create-associations,mcp__hubspot__hubspot-create-engagement,mcp__hubspot__hubspot-update-engagement,mcp__hubspot__hubspot-create-property,mcp__hubspot__hubspot-update-property"
             TOOLS="$TOOLS,$WRITE"
           fi
-          echo "CLAUDE_ARGS=--model claude-sonnet-4-6 --max-turns 15 --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
+          echo "CLAUDE_ARGS=--model claude-opus-4-8 --max-turns 15 --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
 
       - name: Run Claude Pocket
         uses: anthropics/claude-code-action@v1

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,7 +2,7 @@
 
 // Clé publique VAPID (notifications push). La privée est un secret GitHub.
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
-const MODEL = 'claude-sonnet-4-6';
+const MODEL = 'claude-opus-4-8';
 
 // ── Stockage local ────────────────────────────────────────────────────────
 const LS = {

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — shell offline + notifications push.
-const CACHE = 'pocket-v3';
+const CACHE = 'pocket-v4';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
Modèle Pocket = claude-opus-4-8. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Pocket to use the new Claude Opus 4.8 model and refresh its offline cache version.

Enhancements:
- Switch the Pocket GitHub workflow and web client configuration from the Sonnet 4.6 model to the Opus 4.8 model.
- Bump the Pocket service worker cache version to trigger clients to reload updated assets.