### PR TITLE
feat(pocket): v4 — chat itératif + historique catégorisé + navigation

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -6,6 +6,8 @@ name: Claude Pocket
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: pocket-${{ github.event.issue.number }}
@@ -21,21 +23,22 @@ jobs:
     steps:
       - name: Check trigger
         id: check
+        env:
+          EVENT: ${{ github.event_name }}
+          TRIGGER_LABEL: ${{ github.event.label.name }}
+          COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
         run: |
           LABELS='${{ toJSON(github.event.issue.labels.*.name) }}'
-          TRIGGER="${{ github.event.label.name }}"
-          # On ne déclenche que sur l'ajout du label `pocket` ou `approved`,
-          # et seulement si l'issue porte bien le label `pocket`.
-          if echo "$LABELS" | grep -q '"pocket"' && { [[ "$TRIGGER" == "pocket" ]] || [[ "$TRIGGER" == "approved" ]]; }; then
-            echo "run=true" >> $GITHUB_OUTPUT
-          else
-            echo "run=false" >> $GITHUB_OUTPUT
+          RUN=false
+          if [[ "$EVENT" == "issues" ]]; then
+            # création/approbation : seulement sur l'ajout du label pocket/approved
+            if echo "$LABELS" | grep -q '"pocket"' && { [[ "$TRIGGER_LABEL" == "pocket" ]] || [[ "$TRIGGER_LABEL" == "approved" ]]; }; then RUN=true; fi
+          elif [[ "$EVENT" == "issue_comment" ]]; then
+            # chat itératif : un commentaire HUMAIN (pas un bot) sur une tâche pocket relance l'agent
+            if echo "$LABELS" | grep -q '"pocket"' && [[ "$COMMENT_USER_TYPE" == "User" ]]; then RUN=true; fi
           fi
-          if echo "$LABELS" | grep -q '"approved"'; then
-            echo "approved=true" >> $GITHUB_OUTPUT
-          else
-            echo "approved=false" >> $GITHUB_OUTPUT
-          fi
+          echo "run=$RUN" >> $GITHUB_OUTPUT
+          if echo "$LABELS" | grep -q '"approved"'; then echo "approved=true" >> $GITHUB_OUTPUT; else echo "approved=false" >> $GITHUB_OUTPUT; fi
 
       - name: Build task JSON
         id: build
@@ -45,15 +48,20 @@ jobs:
           TITLE: ${{ github.event.issue.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           APPROVED: ${{ steps.check.outputs.approved }}
+          EVENT: ${{ github.event_name }}
+          COMMENT: ${{ github.event.comment.body }}
         run: |
           python3 << 'PYEOF'
           import json, os
+          event = os.environ.get("EVENT", "")
           task = {
               "source": "pocket",
               "issue_number": os.environ.get("ISSUE_NUMBER", ""),
               "title": os.environ.get("TITLE", ""),
               "description": os.environ.get("DESCRIPTION", ""),
               "approved": os.environ.get("APPROVED", "false") == "true",
+              "is_followup": event == "issue_comment",
+              "latest_message": os.environ.get("COMMENT", "") if event == "issue_comment" else "",
           }
           with open("/tmp/task.json", "w") as f:
               json.dump(task, f)
@@ -132,9 +140,15 @@ jobs:
             la/les bonne(s) app(s), et tu agis. Le champ "Workflow" n'est qu'un raccourci optionnel.
 
             === DÉMARRAGE ===
-            - `cat /tmp/agent_task.json` (Demande, approved, issue_number) et `cat docs/runner-guardrails.md`.
-            - Poste tout de suite un bref commentaire de progression (1 ligne) pour que Gaspard voie que tu as démarré :
+            - `cat /tmp/agent_task.json` (Demande, approved, issue_number, is_followup, latest_message) et `cat docs/runner-guardrails.md`.
+            - **Lis TOUT le fil de la conversation** (c'est un chat itératif) :
+              `gh issue view ${{ github.event.issue.number }} --comments`
+              Les commentaires de `github-actions` = tes réponses précédentes ; les autres = les messages de Gaspard.
+            - Si `is_followup` = true, tu RÉPONDS au `latest_message` de Gaspard **en tenant compte de tout l'échange** (itération sur un résultat précédent). Sinon, c'est une nouvelle demande (le corps de l'issue).
+            - Poste tout de suite un bref commentaire de progression (1 ligne) :
               `gh issue comment ${{ github.event.issue.number }} --body "▶️ Compris : <reformulation> — je m'en occupe."`
+            - **Classe la tâche** (une seule fois, si pas déjà fait) en ajoutant UN label catégorie selon le domaine principal :
+              `gh issue edit ${{ github.event.issue.number }} --add-label "cat:crm"` (HubSpot/leads) — ou `cat:enrich` (FullEnrich/PhantomBuster), `cat:outreach` (Lemlist), `cat:web` (recherche web), `cat:vault` (connaissance/docs du repo), `cat:code` (dev/repo), `cat:other`. N'ajoute le label que s'il n'y en a pas déjà un `cat:*`.
 
             === APPS DISPONIBLES (choisis selon la demande) ===
             - **HubSpot (CRM)** — `python3 scripts/pocket_hubspot.py count|search|read|whoami` (lecture fiable, token en env).

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -1,200 +1,166 @@
 'use strict';
 
-// Clé publique VAPID (notifications push). La privée est un secret GitHub.
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
+const CATS = {
+  'cat:crm': { label: 'CRM', color: '#3b6fd4' },
+  'cat:enrich': { label: 'Enrichissement', color: '#8957e5' },
+  'cat:outreach': { label: 'Outreach', color: '#2da44e' },
+  'cat:web': { label: 'Web', color: '#bf8700' },
+  'cat:vault': { label: 'Vault', color: '#1f8f9a' },
+  'cat:code': { label: 'Code', color: '#bf3989' },
+  'cat:other': { label: 'Autre', color: '#57606a' },
+};
 
-// ── Stockage local ────────────────────────────────────────────────────────
 const LS = {
-  get repo() { return localStorage.getItem('pocket_repo') || ''; },
-  set repo(v) { localStorage.setItem('pocket_repo', v); },
-  get pat() { return localStorage.getItem('pocket_pat') || ''; },
-  set pat(v) { localStorage.setItem('pocket_pat', v); },
+  get repo() { return localStorage.getItem('pocket_repo') || ''; }, set repo(v) { localStorage.setItem('pocket_repo', v); },
+  get pat() { return localStorage.getItem('pocket_pat') || ''; }, set pat(v) { localStorage.setItem('pocket_pat', v); },
   get history() { try { return JSON.parse(localStorage.getItem('pocket_history') || '[]'); } catch { return []; } },
   set history(v) { localStorage.setItem('pocket_history', JSON.stringify(v.slice(0, 50))); },
   get device() { let d = localStorage.getItem('pocket_device'); if (!d) { d = 'dev-' + Math.random().toString(36).slice(2, 10); localStorage.setItem('pocket_device', d); } return d; },
 };
-
 const $ = (id) => document.getElementById(id);
-let pollTimer = null;
+let pollTimer = null, allIssues = [], currentFilter = 'all', connectedLogin = '', detailNum = null;
 
 // ── API GitHub ──────────────────────────────────────────────────────────────
 async function gh(path, opts = {}) {
   if (!LS.pat || !LS.repo) throw new Error('Configure le repo et le token (engrenage).');
   const res = await fetch(`https://api.github.com/repos/${LS.repo}${path}`, {
-    ...opts,
-    headers: {
-      'Authorization': `Bearer ${LS.pat}`, 'Accept': 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28', 'Content-Type': 'application/json', ...(opts.headers || {}),
-    },
+    ...opts, headers: { 'Authorization': `Bearer ${LS.pat}`, 'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28', 'Content-Type': 'application/json', ...(opts.headers || {}) },
   });
-  if (!res.ok) {
-    let detail = ''; try { detail = (await res.json()).message || ''; } catch {}
-    const e = new Error(`GitHub ${res.status} ${detail}`.trim()); e.status = res.status; throw e;
-  }
+  if (!res.ok) { let d = ''; try { d = (await res.json()).message || ''; } catch {} const e = new Error(`GitHub ${res.status} ${d}`.trim()); e.status = res.status; throw e; }
   return res.status === 204 ? null : res.json();
 }
 function friendlyError(e) {
-  if (e.status === 403) return `${e.message}\n→ Le token (compte gcoche-bit) doit être un token « classic » avec le scope « repo », et gcoche-bit doit avoir l'accès écriture au repo.`;
-  if (e.status === 401) return `${e.message}\n→ Token invalide/expiré. Recolle-le.`;
+  if (e.status === 403) return `${e.message}\n→ Token « classic » (scope repo) du compte gcoche-bit requis + accès écriture au repo.`;
+  if (e.status === 401) return `${e.message}\n→ Token invalide/expiré.`;
   return e.message;
 }
-
-// ── Écriture d'un fichier dans le repo (subscriptions push) ─────────────────
-function b64(str) { return btoa(unescape(encodeURIComponent(str))); }
+function b64(s) { return btoa(unescape(encodeURIComponent(s))); }
 async function putFile(path, obj) {
-  let sha;
-  try { const cur = await gh(`/contents/${path}`); sha = cur.sha; } catch {}
-  await gh(`/contents/${path}`, {
-    method: 'PUT',
-    body: JSON.stringify({ message: `pocket: push subscription ${LS.device}`, content: b64(JSON.stringify(obj, null, 2)), sha }),
-  });
+  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
+  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: sub ${LS.device}`, content: b64(JSON.stringify(obj, null, 2)), sha }) });
 }
-
 async function ensureLabels() {
-  for (const [name, color] of [['pocket', '8b5cf6'], ['approved', '3fb950']]) {
-    try { await gh('/labels', { method: 'POST', body: JSON.stringify({ name, color }) }); } catch {}
-  }
+  const labels = [['pocket', '8b5cf6'], ['approved', '3fb950'], ...Object.entries(CATS).map(([k, v]) => [k, v.color.replace('#', '')])];
+  for (const [name, color] of labels) { try { await gh('/labels', { method: 'POST', body: JSON.stringify({ name, color }) }); } catch {} }
 }
 
 // ── Dispatch ────────────────────────────────────────────────────────────────
-function buildBody(demande, writeAllowed, conditions) {
-  return [
-    '### Demande', '', demande, '',
-    "### Autoriser l'écriture ?", '', writeAllowed ? 'oui' : 'non', '',
-    "### Conditions d'écriture (si OUI)", '', conditions || '_No response_', '',
-    '### Workflow (recette)', '', 'auto', '',
-    '### Agent (optionnel)', '', 'auto', '',
-  ].join('\n');
+function buildBody(d, w, c) {
+  return ['### Demande', '', d, '', "### Autoriser l'écriture ?", '', w ? 'oui' : 'non', '', "### Conditions d'écriture (si OUI)", '', c || '_No response_', '', '### Workflow (recette)', '', 'auto', '', '### Agent (optionnel)', '', 'auto', ''].join('\n');
 }
 async function dispatch() {
-  const demande = $('demande').value.trim();
-  const msg = $('composer-msg');
+  const demande = $('demande').value.trim(); const msg = $('composer-msg');
   if (!demande) { msg.className = 'msg err'; msg.textContent = 'Écris une demande.'; return; }
-  const writeAllowed = $('write-allowed').checked;
-  const conditions = $('conditions').value.trim();
+  const w = $('write-allowed').checked, c = $('conditions').value.trim();
   msg.className = 'msg'; msg.textContent = 'Envoi…';
   try {
     await ensureLabels();
     const title = '[Pocket] ' + demande.slice(0, 60).replace(/\n/g, ' ');
-    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, writeAllowed, conditions), labels: ['pocket'] }) });
-    const hist = LS.history; hist.unshift({ number: issue.number, title, created: Date.now() }); LS.history = hist;
+    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c), labels: ['pocket'] }) });
     $('demande').value = ''; $('conditions').value = ''; $('write-allowed').checked = false; $('conditions-wrap').classList.add('hidden');
     msg.className = 'msg ok'; msg.textContent = `Tâche #${issue.number} envoyée.`;
-    renderHistory(); openDetail(issue.number, title);
+    navigate('detail:' + issue.number);
   } catch (e) { msg.className = 'msg err'; msg.textContent = friendlyError(e); }
 }
 
-// ── Historique ────────────────────────────────────────────────────────────
+// ── Historique classé par système ───────────────────────────────────────────
+function issueCat(issue) { const l = (issue.labels || []).map((x) => x.name || x).find((n) => n.startsWith('cat:')); return l || null; }
+async function loadHistory() {
+  try { allIssues = await gh('/issues?labels=pocket&state=all&per_page=40&sort=created&direction=desc'); }
+  catch { allIssues = LS.history.map((h) => ({ number: h.number, title: h.title, labels: [], state: 'open' })); }
+  renderFilters(); renderHistory();
+}
+function renderFilters() {
+  const present = new Set(allIssues.map(issueCat).filter(Boolean));
+  const el = $('cat-filters'); el.innerHTML = '';
+  const mk = (key, label) => { const b = document.createElement('button'); b.className = 'chip' + (currentFilter === key ? ' active' : ''); b.textContent = label; b.onclick = () => { currentFilter = key; renderFilters(); renderHistory(); }; return b; };
+  el.appendChild(mk('all', 'Tout'));
+  for (const k of Object.keys(CATS)) if (present.has(k)) el.appendChild(mk(k, CATS[k].label));
+}
 function renderHistory() {
-  const ul = $('history-list'); const hist = LS.history;
-  if (!hist.length) { ul.innerHTML = '<li class="empty">Aucune tâche pour l\'instant.</li>'; return; }
-  ul.innerHTML = '';
-  for (const h of hist) {
+  const ul = $('history-list'); ul.innerHTML = '';
+  let items = allIssues; if (currentFilter !== 'all') items = items.filter((i) => issueCat(i) === currentFilter);
+  if (!items.length) { ul.innerHTML = '<li class="empty">Aucune tâche.</li>'; return; }
+  for (const i of items) {
+    const cat = issueCat(i) || 'cat:other'; const cm = CATS[cat] || CATS['cat:other'];
     const li = document.createElement('li');
-    li.innerHTML = `<span class="t">#${h.number} ${escapeHtml(h.title.replace('[Pocket] ', ''))}</span><span class="badge pending">›</span>`;
-    li.onclick = () => openDetail(h.number, h.title);
+    li.innerHTML = `<span class="t">#${i.number} ${escapeHtml((i.title || '').replace('[Pocket] ', ''))}</span>
+      <span class="meta-r"><span class="cat-badge" style="background:${cm.color}">${cm.label}</span>
+      <span class="badge ${i.state === 'open' ? 'open' : 'pending'}">${i.state === 'open' ? '●' : '✓'}</span></span>`;
+    li.onclick = () => navigate('detail:' + i.number);
     ul.appendChild(li);
   }
 }
 
-// ── Monitoring du run ───────────────────────────────────────────────────────
-const STEP_LABELS = {
-  'Set up job': 'Préparation', 'Run actions/checkout@v4': 'Récupération du code',
-  'Install MCP servers': 'Installation des outils', 'Run actions/setup-python@v5': 'Préparation Python',
-  'Write task to disk': 'Lecture de la demande', 'Write MCP config with secrets': 'Connexion aux apps',
-  'Build claude_args': 'Configuration', 'Run Claude Pocket': 'Claude travaille', 'Notify (push)': 'Notification',
-};
+// ── Monitoring run ──────────────────────────────────────────────────────────
+const STEP_LABELS = { 'Set up job': 'Préparation', 'Run actions/checkout@v4': 'Récupération du code', 'Install MCP servers': 'Installation des outils', 'Run actions/setup-python@v5': 'Préparation Python', 'Write task to disk': 'Lecture de la demande', 'Write MCP config with secrets': 'Connexion aux apps', 'Build claude_args': 'Configuration', 'Run Claude Pocket': 'Claude travaille', 'Notify (push)': 'Notification' };
 async function findRun(title) {
-  try {
-    const d = await gh(`/actions/workflows/pocket.yml/runs?event=issues&per_page=20`);
-    const runs = (d.workflow_runs || []).filter((r) => r.display_title === title);
-    runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-    return runs[0] || null;
-  } catch { return null; }
+  try { const d = await gh(`/actions/workflows/pocket.yml/runs?per_page=30`); const runs = (d.workflow_runs || []).filter((r) => r.display_title === title); runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); return runs[0] || null; } catch { return null; }
 }
-function fmtDur(start, end) {
-  if (!start) return '—';
-  const s = Math.max(0, ((end ? new Date(end) : new Date()) - new Date(start)) / 1000);
-  return s < 60 ? `${Math.round(s)}s` : `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`;
-}
-function cell(k, icon, v, sm) { return `<div class="kcell"><div class="k"><svg class="ic"><use href="#${icon}"/></svg>${k}</div><div class="v ${sm ? 'sm' : ''}">${v}</div></div>`; }
-
+function fmtDur(s, e) { if (!s) return '—'; const x = Math.max(0, ((e ? new Date(e) : new Date()) - new Date(s)) / 1000); return x < 60 ? `${Math.round(x)}s` : `${Math.floor(x / 60)}m${Math.round(x % 60)}s`; }
+function cell(k, icon, v) { return `<div class="kcell"><div class="k"><svg class="ic"><use href="#${icon}"/></svg>${k}</div><div class="v sm">${v}</div></div>`; }
 async function renderRunStatus(run) {
   const bar = $('run-status');
-  if (!run) { bar.className = 'status-bar idle'; bar.textContent = 'Démarrage de la tâche…'; return null; }
-  if (run.status === 'queued') { bar.className = 'status-bar queued'; bar.textContent = 'En file d\'attente…'; return null; }
-  if (run.status === 'completed') {
-    if (run.conclusion === 'success') { bar.className = 'status-bar ok'; bar.textContent = 'Terminé'; }
-    else if (run.conclusion === 'cancelled') { bar.className = 'status-bar idle'; bar.textContent = 'Annulé'; }
-    else { bar.className = 'status-bar err'; bar.textContent = 'Terminé avec un souci — voir la réponse'; }
-    return null;
-  }
+  if (!run) { bar.className = 'status-bar idle'; bar.textContent = 'Démarrage…'; return null; }
+  if (run.status === 'queued') { bar.className = 'status-bar queued'; bar.textContent = 'En file…'; return null; }
+  if (run.status === 'completed') { bar.className = 'status-bar ' + (run.conclusion === 'success' ? 'ok' : (run.conclusion === 'cancelled' ? 'idle' : 'err')); bar.textContent = run.conclusion === 'success' ? 'Terminé' : (run.conclusion === 'cancelled' ? 'Annulé' : 'Terminé avec un souci'); return null; }
   let step = 'Claude travaille', jobs = null;
-  try {
-    jobs = await gh(`/actions/runs/${run.id}/jobs`);
-    const job = (jobs.jobs || []).find((j) => j.status === 'in_progress') || (jobs.jobs || [])[0];
-    const cur = job && (job.steps || []).find((s) => s.status === 'in_progress');
-    if (cur) step = STEP_LABELS[cur.name] || cur.name;
-  } catch {}
-  bar.className = 'status-bar running'; bar.textContent = step + '…';
-  return jobs;
+  try { jobs = await gh(`/actions/runs/${run.id}/jobs`); const job = (jobs.jobs || []).find((j) => j.status === 'in_progress') || (jobs.jobs || [])[0]; const cur = job && (job.steps || []).find((s) => s.status === 'in_progress'); if (cur) step = STEP_LABELS[cur.name] || cur.name; } catch {}
+  bar.className = 'status-bar running'; bar.textContent = step + '…'; return jobs;
 }
-
 async function renderMonitor(run, jobs) {
   const el = $('monitor');
-  let html = '<div class="kgrid">';
-  html += cell('Modèle', 'i-brain', MODEL, true);
-  html += cell('Agent', 'i-robot', 'Claude Pocket', true);
-  html += cell('Statut', 'i-info', run ? (run.status === 'completed' ? (run.conclusion || 'fini') : run.status) : '—', true);
-  html += cell('Durée', 'i-clock', run ? fmtDur(run.run_started_at, run.status === 'completed' ? run.updated_at : null) : '—', true);
-  html += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Contexte</div><div class="v sm">Fenêtre ~200K tokens · session neuve à chaque tâche (pas de mémoire entre tâches)</div></div>`;
-  html += '</div>';
-  // Timeline des étapes (= ce que Claude fait)
+  let h = '<div class="kgrid">';
+  h += cell('Modèle', 'i-brain', MODEL) + cell('Agent', 'i-robot', 'Claude Pocket');
+  h += cell('Statut', 'i-info', run ? (run.status === 'completed' ? (run.conclusion || 'fini') : run.status) : '—');
+  h += cell('Durée', 'i-clock', run ? fmtDur(run.run_started_at, run.status === 'completed' ? run.updated_at : null) : '—');
+  h += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Contexte</div><div class="v sm">~200K tokens · session neuve par tâche (le fil de chat sert de mémoire)</div></div></div>`;
   if (!jobs && run && run.status !== 'completed') { try { jobs = await gh(`/actions/runs/${run.id}/jobs`); } catch {} }
   const job = jobs && ((jobs.jobs || []).find((j) => j.name && j.name.includes('pocket')) || (jobs.jobs || [])[0]);
-  if (job && job.steps) {
-    const shown = job.steps.filter((s) => STEP_LABELS[s.name]);
-    html += '<div class="steps">';
-    for (const s of shown) {
-      const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : '');
-      html += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}</div>`;
-    }
-    html += '</div>';
-  }
-  el.innerHTML = html;
+  if (job && job.steps) { h += '<div class="steps">'; for (const s of job.steps.filter((s) => STEP_LABELS[s.name])) { const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : ''); h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}</div>`; } h += '</div>'; }
+  el.innerHTML = h;
 }
 
-// ── Détail tâche ────────────────────────────────────────────────────────────
-async function openDetail(number, title) {
-  stopPoll(); show('detail');
+// ── Détail + chat ───────────────────────────────────────────────────────────
+function loadDetail(number) {
+  stopPoll(); detailNum = number;
   $('detail-title').textContent = `Tâche #${number}`;
   $('run-status').className = 'status-bar idle'; $('run-status').textContent = 'Chargement…';
   $('monitor').innerHTML = ''; $('comments').innerHTML = ''; $('approve').classList.add('hidden'); $('detail-msg').textContent = '';
   const load = async () => {
+    if (detailNum !== number) return;
     try {
-      const [issue, comments] = await Promise.all([gh(`/issues/${number}`), gh(`/issues/${number}/comments`)]);
-      const t = title || issue.title;
-      const approved = issue.labels.map((l) => l.name).includes('approved');
-      const run = await findRun(t);
+      const [issue, comments] = await Promise.all([gh(`/issues/${number}`), gh(`/issues/${number}/comments?per_page=100`)]);
+      const approved = (issue.labels || []).map((l) => l.name).includes('approved');
+      const run = await findRun(issue.title);
       const jobs = await renderRunStatus(run);
       await renderMonitor(run, jobs);
       const c = $('comments'); c.innerHTML = '';
-      if (!comments.length) c.innerHTML = '<p class="empty">En attente de Claude…</p>';
-      else for (const cm of comments) {
-        const prog = /^▶️|^🔎|^📊|^🧠|^⏳|je m'en occupe|^je /i.test(cm.body.trim());
-        const div = document.createElement('div'); div.className = 'comment' + (prog ? ' progress' : '');
-        div.innerHTML = `<div class="who">${escapeHtml(cm.user.login)} · ${timeago(cm.created_at)}</div>${escapeHtml(cm.body)}`;
-        c.appendChild(div);
+      const body = (issue.body || '').split('### Autoriser')[0].replace('### Demande', '').trim();
+      if (body) c.appendChild(bubble(connectedLogin || 'toi', body, 'user', issue.created_at));
+      for (const cm of comments) {
+        const isUser = cm.user.type === 'User';
+        const prog = !isUser && /^▶️|^🔎|^📊|^🧠|^⏳|m'en occupe/i.test(cm.body.trim());
+        c.appendChild(bubble(cm.user.login, cm.body, isUser ? 'user' : 'assistant', cm.created_at, prog));
       }
-      const needsApproval = comments.some((cm) => /preview|approb|approuv|approved/i.test(cm.body)) && !approved && issue.state === 'open';
-      $('approve').classList.toggle('hidden', !needsApproval);
-      $('approve').onclick = () => approve(number);
-      if (run && run.status === 'completed') stopPoll();
+      const needsApproval = comments.some((cm) => /preview|approb|approuv/i.test(cm.body)) && !approved && issue.state === 'open';
+      $('approve').classList.toggle('hidden', !needsApproval); $('approve').onclick = () => approve(number);
     } catch (e) { $('detail-msg').className = 'msg err'; $('detail-msg').textContent = friendlyError(e); stopPoll(); }
   };
-  await load();
-  pollTimer = setInterval(load, 6000);
+  load(); pollTimer = setInterval(load, 6000);
+}
+function bubble(who, text, kind, ts, prog) {
+  const div = document.createElement('div'); div.className = 'comment ' + kind + (prog ? ' progress' : '');
+  div.innerHTML = `<div class="who">${escapeHtml(who)}${ts ? ' · ' + timeago(ts) : ''}</div>${escapeHtml(text)}`; return div;
+}
+async function chatSend() {
+  const ta = $('chat-input'), txt = ta.value.trim(); if (!txt || detailNum == null) return;
+  ta.value = ''; ta.style.height = 'auto';
+  $('comments').appendChild(bubble(connectedLogin || 'toi', txt, 'user', new Date().toISOString()));
+  try { await gh(`/issues/${detailNum}/comments`, { method: 'POST', body: JSON.stringify({ body: txt }) }); setTimeout(() => { if (detailNum != null) loadDetail(detailNum); }, 900); }
+  catch (e) { $('detail-msg').className = 'msg err'; $('detail-msg').textContent = friendlyError(e); }
 }
 async function approve(number) {
   const m = $('detail-msg'); m.className = 'msg'; m.textContent = 'Approbation…';
@@ -203,112 +169,92 @@ async function approve(number) {
 }
 function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
-// ── Vue Système (device + Claude) ───────────────────────────────────────────
+// ── Système ─────────────────────────────────────────────────────────────────
 async function renderSystem() {
-  const dev = [];
-  dev.push(cell('CPU (cœurs)', 'i-cpu', navigator.hardwareConcurrency || '—', true));
-  dev.push(cell('Mémoire', 'i-cpu', navigator.deviceMemory ? navigator.deviceMemory + ' Go' : 'non exposé', true));
-  dev.push(cell('Plateforme', 'i-info', escapeHtml(navigator.platform || '—'), true));
-  dev.push(cell('Écran', 'i-info', `${screen.width}×${screen.height}`, true));
-  const conn = navigator.connection && navigator.connection.effectiveType;
-  dev.push(cell('Réseau', 'i-info', conn || 'non exposé (iOS)', true));
-  let bat = 'non exposé (iOS)';
-  if (navigator.getBattery) { try { const b = await navigator.getBattery(); bat = Math.round(b.level * 100) + '%' + (b.charging ? ' ⚡' : ''); } catch {} }
-  dev.push(cell('Batterie', 'i-info', bat, true));
-  $('system-grid').innerHTML = dev.join('');
-  $('claude-grid').innerHTML = [
-    cell('Modèle', 'i-brain', MODEL, true),
-    cell('Tours max', 'i-info', '15', true),
-    cell('Exécution', 'i-robot', 'GitHub Actions (cloud)', true),
-    cell('Contexte', 'i-brain', '~200K, neuf par tâche', true),
-  ].join('');
+  const d = [];
+  d.push(cell('CPU (cœurs)', 'i-cpu', navigator.hardwareConcurrency || '—'));
+  d.push(cell('Mémoire', 'i-cpu', navigator.deviceMemory ? navigator.deviceMemory + ' Go' : 'non exposé'));
+  d.push(cell('Plateforme', 'i-info', escapeHtml(navigator.platform || '—')));
+  d.push(cell('Écran', 'i-info', `${screen.width}×${screen.height}`));
+  d.push(cell('Réseau', 'i-info', (navigator.connection && navigator.connection.effectiveType) || 'non exposé'));
+  let bat = 'non exposé (iOS)'; if (navigator.getBattery) { try { const b = await navigator.getBattery(); bat = Math.round(b.level * 100) + '%' + (b.charging ? ' ⚡' : ''); } catch {} }
+  d.push(cell('Batterie', 'i-info', bat));
+  $('system-grid').innerHTML = d.join('');
+  $('claude-grid').innerHTML = [cell('Modèle', 'i-brain', MODEL), cell('Tours max', 'i-info', '15'), cell('Exécution', 'i-robot', 'GitHub Actions'), cell('Contexte', 'i-brain', '~200K, neuf/tâche')].join('');
 }
 
-// ── Notifications push ──────────────────────────────────────────────────────
-function urlB64ToUint8Array(b64s) {
-  const pad = '='.repeat((4 - b64s.length % 4) % 4);
-  const base = (b64s + pad).replace(/-/g, '+').replace(/_/g, '/');
-  const raw = atob(base); const arr = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
-  return arr;
-}
+// ── Push ────────────────────────────────────────────────────────────────────
+function urlB64ToUint8Array(s) { const p = '='.repeat((4 - s.length % 4) % 4); const b = (s + p).replace(/-/g, '+').replace(/_/g, '/'); const r = atob(b); const a = new Uint8Array(r.length); for (let i = 0; i < r.length; i++) a[i] = r.charCodeAt(i); return a; }
 async function enablePush() {
   const m = $('push-msg'); m.className = 'msg';
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    m.className = 'msg err'; m.textContent = 'Push non disponible. Sur iPhone : ouvre l\'app DEPUIS l\'écran d\'accueil (iOS 16.4+).'; return;
-  }
-  m.textContent = 'Demande d\'autorisation…';
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) { m.className = 'msg err'; m.textContent = 'Push indisponible. Ouvre l\'app depuis l\'écran d\'accueil (iOS 16.4+).'; return; }
+  m.textContent = 'Autorisation…';
   try {
-    const perm = await Notification.requestPermission();
-    if (perm !== 'granted') { m.className = 'msg err'; m.textContent = 'Permission refusée.'; return; }
+    if (await Notification.requestPermission() !== 'granted') { m.className = 'msg err'; m.textContent = 'Permission refusée.'; return; }
     const reg = await navigator.serviceWorker.ready;
     let sub = await reg.pushManager.getSubscription();
     if (!sub) sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlB64ToUint8Array(VAPID_PUBLIC) });
     await putFile(`pocket-data/sub-${LS.device}.json`, sub.toJSON());
-    m.className = 'msg ok'; m.textContent = '✅ Notifications activées — tu seras prévenu à la fin de chaque tâche.';
+    m.className = 'msg ok'; m.textContent = '✅ Notifications activées.';
   } catch (e) { m.className = 'msg err'; m.textContent = 'Échec : ' + (e.message || e); }
 }
 
-// ── Navigation ──────────────────────────────────────────────────────────────
-function show(which) {
-  $('detail').classList.toggle('hidden', which !== 'detail');
-  $('system').classList.toggle('hidden', which !== 'system');
-  for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', which === 'detail' || which === 'system');
-  if (which !== 'detail') stopPoll();
+// ── Router ──────────────────────────────────────────────────────────────────
+function applyView(view) {
+  const isDetail = view.startsWith('detail:');
+  $('detail').classList.toggle('hidden', !isDetail);
+  $('system').classList.toggle('hidden', view !== 'system');
+  for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', isDetail || view === 'system');
+  if (!isDetail) stopPoll();
+  if (view === 'system') renderSystem();
+  else if (isDetail) loadDetail(parseInt(view.split(':')[1], 10));
+  else { detailNum = null; loadHistory(); }
+  window.scrollTo(0, 0);
 }
-function escapeHtml(s) { return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }
-function timeago(iso) { const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 60) return 'à l\'instant'; if (s < 3600) return `il y a ${Math.floor(s / 60)} min`; return `il y a ${Math.floor(s / 3600)} h`; }
+function navigate(view) { history.pushState({ view }, '', '#' + view); applyView(view); }
 
+function escapeHtml(s) { return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }
+function timeago(iso) { const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 60) return 'à l\'instant'; if (s < 3600) return `il y a ${Math.floor(s / 60)} min`; if (s < 86400) return `il y a ${Math.floor(s / 3600)} h`; return `il y a ${Math.floor(s / 86400)} j`; }
 async function testConn(silent) {
   const dot = $('conn-dot');
-  try { const r = await gh(''); dot.className = 'dot ok'; return r; }
+  try { const r = await gh(''); dot.className = 'dot ok'; try { const u = await (await fetch('https://api.github.com/user', { headers: { Authorization: `Bearer ${LS.pat}`, Accept: 'application/vnd.github+json' } })).json(); if (u && u.login) connectedLogin = u.login; } catch {} return r; }
   catch { dot.className = 'dot err'; if (!silent) throw new Error('non connecté'); return null; }
-}
-
-// ── Init ────────────────────────────────────────────────────────────────────
-function init() {
-  $('repo').value = LS.repo || 'GaspardCoche/agent-system';
-  $('pat').value = LS.pat;
-  if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
-
-  $('nav-settings').onclick = () => $('settings').classList.toggle('hidden');
-  $('nav-system').onclick = () => { renderSystem(); show('system'); };
-  $('system-back').onclick = () => show('main');
-  $('back').onclick = () => { show('main'); renderHistory(); };
-
-  $('save-settings').onclick = async () => {
-    LS.repo = $('repo').value.trim(); LS.pat = $('pat').value.trim();
-    const m = $('settings-msg'); m.className = 'msg'; m.textContent = 'Test de connexion…';
-    try {
-      const r = await testConn(false);
-      let who = '';
-      try { const u = await (await fetch('https://api.github.com/user', { headers: { Authorization: `Bearer ${LS.pat}`, Accept: 'application/vnd.github+json' } })).json(); if (u && u.login) who = ` · ${u.login}`; } catch {}
-      m.className = 'msg ok'; m.textContent = `Connecté à ${r.full_name}${who}`;
-      setTimeout(() => $('settings').classList.add('hidden'), 1400);
-    } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-  };
-  $('enable-push').onclick = enablePush;
-
-  $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
-  $('dispatch').onclick = dispatch;
-  for (const ch of document.querySelectorAll('.chip')) ch.onclick = () => { $('demande').value = ch.dataset.q; $('demande').focus(); };
-
-  setupMic(); renderHistory();
-  if (LS.repo && LS.pat) testConn(true);
-  if ('serviceWorker' in navigator) navigator.serviceWorker.register('sw.js').catch(() => {});
 }
 
 function setupMic() {
   const standalone = window.navigator.standalone === true || matchMedia('(display-mode: standalone)').matches;
-  const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
-  const mic = $('mic');
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition; const mic = $('mic');
   if (standalone || !SR) { mic.style.display = 'none'; $('mic-hint').classList.remove('hidden'); return; }
-  const rec = new SR(); rec.lang = 'fr-FR'; rec.interimResults = true; rec.continuous = true;
-  let base = '', live = false;
+  const rec = new SR(); rec.lang = 'fr-FR'; rec.interimResults = true; rec.continuous = true; let base = '', live = false;
   rec.onresult = (e) => { let t = ''; for (let i = e.resultIndex; i < e.results.length; i++) t += e.results[i][0].transcript; $('demande').value = (base + ' ' + t).trim(); };
-  rec.onerror = () => { live = false; mic.classList.remove('live'); };
-  rec.onend = () => { live = false; mic.classList.remove('live'); };
+  rec.onerror = () => { live = false; mic.classList.remove('live'); }; rec.onend = () => { live = false; mic.classList.remove('live'); };
   mic.onclick = () => { if (live) { rec.stop(); return; } base = $('demande').value; try { rec.start(); live = true; mic.classList.add('live'); } catch {} };
 }
 
+function init() {
+  $('repo').value = LS.repo || 'GaspardCoche/agent-system'; $('pat').value = LS.pat;
+  if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
+  $('nav-settings').onclick = () => $('settings').classList.toggle('hidden');
+  $('nav-system').onclick = () => navigate('system');
+  $('system-back').onclick = () => history.back();
+  $('back').onclick = () => history.back();
+  $('save-settings').onclick = async () => {
+    LS.repo = $('repo').value.trim(); LS.pat = $('pat').value.trim();
+    const m = $('settings-msg'); m.className = 'msg'; m.textContent = 'Test…';
+    try { const r = await testConn(false); m.className = 'msg ok'; m.textContent = `Connecté à ${r.full_name}${connectedLogin ? ' · ' + connectedLogin : ''}`; loadHistory(); setTimeout(() => $('settings').classList.add('hidden'), 1400); }
+    catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
+  };
+  $('enable-push').onclick = enablePush;
+  $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
+  $('dispatch').onclick = dispatch;
+  for (const ch of document.querySelectorAll('#chips .chip')) ch.onclick = () => { $('demande').value = ch.dataset.q; $('demande').focus(); };
+  $('chat-send').onclick = chatSend;
+  $('chat-input').addEventListener('input', (e) => { e.target.style.height = 'auto'; e.target.style.height = Math.min(e.target.scrollHeight, 140) + 'px'; });
+  window.addEventListener('popstate', (e) => applyView((e.state && e.state.view) || 'main'));
+
+  setupMic();
+  history.replaceState({ view: 'main' }, '', '#main');
+  if (LS.repo && LS.pat) { testConn(true).then(loadHistory); } else { renderHistory(); }
+  if ('serviceWorker' in navigator) navigator.serviceWorker.register('sw.js').catch(() => {});
+}
 document.addEventListener('DOMContentLoaded', init);

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -90,9 +90,10 @@
     <p id="composer-msg" class="msg"></p>
   </section>
 
-  <!-- ── Historique ── -->
+  <!-- ── Historique (classé par système) ── -->
   <section id="history" class="card">
     <h2><svg class="ic"><use href="#i-list"/></svg> Tâches récentes</h2>
+    <div class="chips" id="cat-filters"></div>
     <ul id="history-list"></ul>
   </section>
 
@@ -105,6 +106,10 @@
     <div id="comments"></div>
     <button id="approve" class="primary hidden"><svg class="ic"><use href="#i-check"/></svg> Approuver l'écriture</button>
     <p id="detail-msg" class="msg"></p>
+    <div class="chatbar">
+      <textarea id="chat-input" rows="1" placeholder="Réponds ou affine le résultat… (itère)"></textarea>
+      <button id="chat-send" class="icon-btn" title="Envoyer"><svg class="ic"><use href="#i-send"/></svg></button>
+    </div>
   </section>
 
   <script src="app.js"></script>

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -136,3 +136,20 @@ ul { list-style: none; padding: 0; margin: 0; }
 .comment.progress { background: #11203a; border-color: #2c4a7a; color: var(--accent); font-weight: 600; }
 .comment .who { font-size: 11px; color: var(--muted); margin-bottom: 6px; }
 .empty { color: var(--muted); font-size: 13px; }
+
+/* chat bulles */
+.comment.user { background: linear-gradient(135deg, #16263f, #1a2740); border-color: #2c4a7a; margin-left: 28px; }
+.comment.assistant { margin-right: 28px; }
+.comment.user .who { color: var(--accent); }
+
+/* chatbar */
+.chatbar { display: flex; gap: 8px; align-items: flex-end; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--line); }
+.chatbar textarea { flex: 1; margin: 0; min-height: 44px; max-height: 140px; }
+.chatbar .icon-btn { width: 46px; height: 46px; flex: 0 0 auto; background: linear-gradient(135deg, var(--accent), var(--accent2)); border: none; }
+.chatbar .icon-btn .ic { color: #fff; }
+
+/* catégories */
+.cat-badge { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; font-weight: 700; color: #fff; white-space: nowrap; }
+.chip.active { background: var(--accent2); color: #fff; }
+.hgroup { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; margin: 14px 0 8px; }
+#history-list li .meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — shell offline + notifications push.
-const CACHE = 'pocket-v4';
+const CACHE = 'pocket-v5';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
Chat dans les tâches (issue_comment relance l'agent), historique classé par système, routing pushState. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add iterative chat on Pocket issues with categorized history and URL-based navigation.

New Features:
- Introduce iterative chat on tasks by turning user issue comments into follow-up messages that relaunch the Pocket agent.
- Display task history grouped and filterable by functional category with visual badges.
- Add an inline chat bar on the task detail view for replying and refining results.

Enhancements:
- Refine the Pocket UI with assistant/user chat bubbles, compact status/monitoring cards, and small copy and layout tweaks.
- Extend the Pocket agent prompt to read the full issue conversation, handle follow-up messages, and auto-assign a single domain category label per task.
- Improve client-side routing using pushState/hash navigation and persist GitHub user identity for a more contextual UI.

Build:
- Update the Pocket GitHub Actions workflow to trigger on both issue label changes and human-authored issue comments, and to pass richer task metadata (follow-up flag, latest message) to the agent.

Deployment:
- Bump the service worker cache version to force clients to refresh static assets for the new UI and behavior.