### PR TITLE
feat(pocket): v6 — voice, file import, light theme

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -164,7 +164,7 @@ jobs:
             Si une app pertinente manque de secret, dis-le proprement et propose une alternative — ne plante pas.
 
             === MÉTHODE ===
-            1. Comprends l'intention. Si un "Workflow" précis (≠ auto) est indiqué dans la demande, tu peux lire son playbook : `cat agent_prompts/workflows/<workflow>.md`. Sinon, raisonne librement.
+            1. Comprends l'intention. Si la demande contient une section **"### Fichiers joints"**, lis chaque fichier listé avec `cat <chemin>` (ils sont dans le checkout du repo) AVANT d'agir — ex : un CSV de contacts à enrichir/analyser. Si un "Workflow" précis (≠ auto) est indiqué, tu peux lire son playbook : `cat agent_prompts/workflows/<workflow>.md`. Sinon, raisonne librement.
             2. Choisis l'app et agis. **Narre tes étapes** : poste un court commentaire de progression à chaque étape clé (ex : "🔎 Je interroge HubSpot…", "📊 J'analyse…") — c'est ce que Gaspard suit en direct dans son app.
             3. **Lecture par défaut.** Écriture/action coûteuse (HubSpot write, FullEnrich --confirm, PhantomBuster launch, Lemlist add/send) UNIQUEMENT si `approved` = true ET demandée ET dans les garde-fous. Sinon, poste un PREVIEW de ce que tu ferais et demande le label `approved`.
             4. Poste le RÉSULTAT FINAL en commentaire (clair, prêt à copier, même langue que la demande) :

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -18,9 +18,10 @@ const LS = {
   get history() { try { return JSON.parse(localStorage.getItem('pocket_history') || '[]'); } catch { return []; } },
   set history(v) { localStorage.setItem('pocket_history', JSON.stringify(v.slice(0, 50))); },
   get device() { let d = localStorage.getItem('pocket_device'); if (!d) { d = 'dev-' + Math.random().toString(36).slice(2, 10); localStorage.setItem('pocket_device', d); } return d; },
+  get theme() { return localStorage.getItem('pocket_theme') || 'auto'; }, set theme(v) { localStorage.setItem('pocket_theme', v); },
 };
 const $ = (id) => document.getElementById(id);
-let pollTimer = null, allIssues = [], currentFilter = 'all', connectedLogin = '', detailNum = null;
+let pollTimer = null, allIssues = [], currentFilter = 'all', connectedLogin = '', detailNum = null, attachedFiles = [];
 
 // ── API GitHub ──────────────────────────────────────────────────────────────
 async function gh(path, opts = {}) {
@@ -41,6 +42,30 @@ async function putFile(path, obj) {
   let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
   await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: sub ${LS.device}`, content: b64(JSON.stringify(obj, null, 2)), sha }) });
 }
+async function putRaw(path, b64content) {
+  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
+  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: upload ${path}`, content: b64content, sha }) });
+}
+
+// ── Import de fichiers ──────────────────────────────────────────────────────
+function addFiles(fileList) {
+  for (const f of fileList) {
+    if (f.size > 4 * 1024 * 1024) { alert(`${f.name} dépasse 4 Mo — ignoré.`); continue; }
+    const r = new FileReader();
+    r.onload = () => { attachedFiles.push({ name: f.name, size: f.size, b64: String(r.result).split(',')[1] || '' }); renderFileList(); };
+    r.readAsDataURL(f);
+  }
+}
+function renderFileList() {
+  const el = $('file-list'); el.innerHTML = '';
+  attachedFiles.forEach((f, i) => {
+    const kb = Math.max(1, Math.round(f.size / 1024));
+    const row = document.createElement('div'); row.className = 'file-row';
+    row.innerHTML = `<span class="fx">📎 ${escapeHtml(f.name)} · ${kb} Ko</span><button title="Retirer">×</button>`;
+    row.querySelector('button').onclick = () => { attachedFiles.splice(i, 1); renderFileList(); };
+    el.appendChild(row);
+  });
+}
 async function ensureLabels() {
   const labels = [['pocket', '8b5cf6'], ['approved', '3fb950'], ...Object.entries(CATS).map(([k, v]) => [k, v.color.replace('#', '')])];
   for (const [name, color] of labels) { try { await gh('/labels', { method: 'POST', body: JSON.stringify({ name, color }) }); } catch {} }
@@ -57,9 +82,21 @@ async function dispatch() {
   msg.className = 'msg'; msg.textContent = 'Envoi…';
   try {
     await ensureLabels();
+    let attachNote = '';
+    if (attachedFiles.length) {
+      msg.textContent = 'Envoi des fichiers…';
+      const paths = [];
+      for (const f of attachedFiles) {
+        const path = `pocket-data/uploads/${Date.now()}-${f.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+        await putRaw(path, f.b64); paths.push(path);
+      }
+      attachNote = '\n\n### Fichiers joints\n' + paths.map((p) => '- `' + p + '` (lis-le avec `cat ' + p + '`)').join('\n');
+      msg.textContent = 'Envoi…';
+    }
     const title = '[Pocket] ' + demande.slice(0, 60).replace(/\n/g, ' ');
-    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c), labels: ['pocket'] }) });
+    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c) + attachNote, labels: ['pocket'] }) });
     $('demande').value = ''; $('conditions').value = ''; $('write-allowed').checked = false; $('conditions-wrap').classList.add('hidden');
+    attachedFiles = []; renderFileList();
     msg.className = 'msg ok'; msg.textContent = `Tâche #${issue.number} envoyée.`;
     navigate('detail:' + issue.number);
   } catch (e) { msg.className = 'msg err'; msg.textContent = friendlyError(e); }
@@ -222,13 +259,22 @@ async function testConn(silent) {
 }
 
 function setupMic() {
-  const standalone = window.navigator.standalone === true || matchMedia('(display-mode: standalone)').matches;
   const SR = window.SpeechRecognition || window.webkitSpeechRecognition; const mic = $('mic');
-  if (standalone || !SR) { mic.style.display = 'none'; $('mic-hint').classList.remove('hidden'); return; }
+  $('mic-hint').classList.remove('hidden'); // l'astuce clavier reste toujours dispo
+  if (!SR) { mic.style.display = 'none'; return; }
   const rec = new SR(); rec.lang = 'fr-FR'; rec.interimResults = true; rec.continuous = true; let base = '', live = false;
   rec.onresult = (e) => { let t = ''; for (let i = e.resultIndex; i < e.results.length; i++) t += e.results[i][0].transcript; $('demande').value = (base + ' ' + t).trim(); };
-  rec.onerror = () => { live = false; mic.classList.remove('live'); }; rec.onend = () => { live = false; mic.classList.remove('live'); };
-  mic.onclick = () => { if (live) { rec.stop(); return; } base = $('demande').value; try { rec.start(); live = true; mic.classList.add('live'); } catch {} };
+  rec.onerror = (e) => { live = false; mic.classList.remove('live'); if (e && e.error === 'not-allowed') { const m = $('composer-msg'); m.className = 'msg err'; m.textContent = 'Micro refusé. Utilise le micro du clavier iOS (astuce ci-dessus).'; } };
+  rec.onend = () => { live = false; mic.classList.remove('live'); };
+  mic.onclick = () => { if (live) { rec.stop(); return; } base = $('demande').value; try { rec.start(); live = true; mic.classList.add('live'); } catch { mic.classList.remove('live'); } };
+}
+
+// ── Thème ───────────────────────────────────────────────────────────────────
+function applyTheme(t) {
+  if (t === 'auto') document.documentElement.removeAttribute('data-theme');
+  else document.documentElement.setAttribute('data-theme', t);
+  for (const b of document.querySelectorAll('#theme-seg button')) b.classList.toggle('active', b.dataset.theme === t);
+  const meta = document.querySelector('meta[name=theme-color]'); if (meta) meta.setAttribute('content', t === 'light' ? '#eef1f7' : '#0a0e16');
 }
 
 function init() {
@@ -245,6 +291,12 @@ function init() {
     catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
   };
   $('enable-push').onclick = enablePush;
+  // Thème
+  applyTheme(LS.theme);
+  for (const b of document.querySelectorAll('#theme-seg button')) b.onclick = () => { LS.theme = b.dataset.theme; applyTheme(b.dataset.theme); };
+  // Import de fichiers
+  $('attach-btn').onclick = () => $('file-input').click();
+  $('file-input').onchange = (e) => { addFiles(e.target.files); e.target.value = ''; };
   $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
   $('dispatch').onclick = dispatch;
   for (const ch of document.querySelectorAll('#chips .chip')) ch.onclick = () => { $('demande').value = ch.dataset.q; $('demande').focus(); };

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -31,6 +31,8 @@
       <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 16v-4M12 8h.01"/></symbol>
       <symbol id="i-list" viewBox="0 0 24 24"><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></symbol>
       <symbol id="i-plus" viewBox="0 0 24 24"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M12 5v14M5 12h14"/></symbol>
+      <symbol id="i-clip" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M21.4 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.2-9.19a4 4 0 015.65 5.66l-9.2 9.19a2 2 0 01-2.82-2.83l8.48-8.48"/></symbol>
+      <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.8"/><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></symbol>
     </defs>
   </svg>
 
@@ -53,6 +55,13 @@
     </label>
     <button id="save-settings" class="primary">Enregistrer &amp; tester</button>
     <p id="settings-msg" class="msg"></p>
+    <label style="margin-top:14px">Thème
+      <div class="seg" id="theme-seg">
+        <button data-theme="auto">Auto</button>
+        <button data-theme="light"><svg class="ic"><use href="#i-sun"/></svg> Clair</button>
+        <button data-theme="dark">Sombre</button>
+      </div>
+    </label>
     <button id="enable-push" class="ghost"><svg class="ic"><use href="#i-bell"/></svg> Activer les notifications</button>
     <p id="push-msg" class="msg"></p>
   </section>
@@ -74,7 +83,10 @@
       <textarea id="demande" rows="4" placeholder="Décris ta demande en langage naturel… (ex : combien de leads en France ?)"></textarea>
       <button id="mic" class="icon-btn mic" title="Dicter"><svg class="ic"><use href="#i-mic"/></svg></button>
     </div>
-    <p id="mic-hint" class="hint hidden">Dictée : touche le champ puis le micro du clavier iOS.</p>
+    <p id="mic-hint" class="hint hidden">Astuce dictée : tu peux aussi toucher le champ puis le micro du clavier iOS.</p>
+    <input id="file-input" type="file" multiple class="hidden" />
+    <button id="attach-btn" class="ghost" style="margin-top:8px"><svg class="ic"><use href="#i-clip"/></svg> Joindre un fichier (CSV, doc…)</button>
+    <div id="file-list" class="file-list"></div>
     <div class="chips" id="chips">
       <button class="chip" data-q="Combien de contacts par lifecyclestage ?">Stats CRM</button>
       <button class="chip" data-q="Liste mes phantoms PhantomBuster et leur dernier run.">PhantomBuster</button>

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -12,6 +12,17 @@
   --err: #f85149;
   --radius: 16px;
 }
+/* Thème clair : explicite, ou auto via préférence système */
+:root[data-theme="light"] {
+  --bg: #eef1f7; --card: #ffffff; --card2: #f1f4f9; --line: #d9e0ec;
+  --text: #18202e; --muted: #5b6781; --accent: #2f6fe0; --accent2: #2056bd;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --bg: #eef1f7; --card: #ffffff; --card2: #f1f4f9; --line: #d9e0ec;
+    --text: #18202e; --muted: #5b6781; --accent: #2f6fe0; --accent2: #2056bd;
+  }
+}
 * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
 html, body { margin: 0; background: var(--bg); }
 body {
@@ -153,3 +164,15 @@ ul { list-style: none; padding: 0; margin: 0; }
 .chip.active { background: var(--accent2); color: #fff; }
 .hgroup { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; margin: 14px 0 8px; }
 #history-list li .meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+
+/* segmented control (thème) */
+.seg { display: flex; gap: 0; margin-top: 6px; background: var(--card2); border: 1px solid var(--line); border-radius: 11px; overflow: hidden; }
+.seg button { flex: 1; padding: 10px; background: transparent; color: var(--muted); font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 5px; }
+.seg button.active { background: var(--accent2); color: #fff; }
+.seg button .ic { width: 14px; height: 14px; }
+
+/* fichiers joints */
+.file-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.file-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12.5px; background: var(--card2); border: 1px solid var(--line); border-radius: 9px; padding: 8px 10px; }
+.file-row .fx { color: var(--muted); font-weight: 600; }
+.file-row button { background: none; color: var(--err); font-size: 16px; line-height: 1; padding: 0 4px; }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — shell offline + notifications push.
-const CACHE = 'pocket-v5';
+const CACHE = 'pocket-v6';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
Voix réactivée, import de fichiers (CSV/docs), thème clair. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add file attachment support, a selectable light theme, and improved voice dictation handling to the Pocket web app.

New Features:
- Allow users to attach multiple files to a task, store them in the repository, and reference them in the created GitHub issue.
- Introduce a theme selector with auto, light, and dark modes, persisted in local storage and reflected in UI styling.
- Expose a UI control for attaching files from the task composer, including visual listing and removal of selected files.

Enhancements:
- Re-enable and improve microphone dictation support with better error handling and guidance when permission is denied.
- Update the Pocket service worker cache version to v6 for the new assets.
- Extend the agent workflow instructions so that attached files listed in issues are read before acting.