### PR TITLE
fix(pocket): network-first SW + auto-update + version badge

### DIFF
--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,6 +2,7 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
+const APP_VERSION = 'v7';
 const CATS = {
   'cat:crm': { label: 'CRM', color: '#3b6fd4' },
   'cat:enrich': { label: 'Enrichissement', color: '#8957e5' },
@@ -217,7 +218,7 @@ async function renderSystem() {
   let bat = 'non exposé (iOS)'; if (navigator.getBattery) { try { const b = await navigator.getBattery(); bat = Math.round(b.level * 100) + '%' + (b.charging ? ' ⚡' : ''); } catch {} }
   d.push(cell('Batterie', 'i-info', bat));
   $('system-grid').innerHTML = d.join('');
-  $('claude-grid').innerHTML = [cell('Modèle', 'i-brain', MODEL), cell('Tours max', 'i-info', '15'), cell('Exécution', 'i-robot', 'GitHub Actions'), cell('Contexte', 'i-brain', '~200K, neuf/tâche')].join('');
+  $('claude-grid').innerHTML = [cell('Modèle', 'i-brain', MODEL), cell('Version app', 'i-info', APP_VERSION), cell('Exécution', 'i-robot', 'GitHub Actions'), cell('Contexte', 'i-brain', '~200K, neuf/tâche')].join('');
 }
 
 // ── Push ────────────────────────────────────────────────────────────────────
@@ -304,9 +305,15 @@ function init() {
   $('chat-input').addEventListener('input', (e) => { e.target.style.height = 'auto'; e.target.style.height = Math.min(e.target.scrollHeight, 140) + 'px'; });
   window.addEventListener('popstate', (e) => applyView((e.state && e.state.view) || 'main'));
 
+  const vb = $('ver-badge'); if (vb) vb.textContent = APP_VERSION;
+
   setupMic();
   history.replaceState({ view: 'main' }, '', '#main');
   if (LS.repo && LS.pat) { testConn(true).then(loadHistory); } else { renderHistory(); }
-  if ('serviceWorker' in navigator) navigator.serviceWorker.register('sw.js').catch(() => {});
+  if ('serviceWorker' in navigator) {
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener('controllerchange', () => { if (refreshing) return; refreshing = true; location.reload(); });
+    navigator.serviceWorker.register('sw.js').catch(() => {});
+  }
 }
 document.addEventListener('DOMContentLoaded', init);

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -37,7 +37,7 @@
   </svg>
 
   <header>
-    <div class="brand"><span class="dot" id="conn-dot"></span> Claude Pocket</div>
+    <div class="brand"><span class="dot" id="conn-dot"></span> Claude Pocket <span id="ver-badge" class="ver">v7</span></div>
     <div class="hbtns">
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
       <button class="icon-btn" id="nav-settings" title="Réglages"><svg class="ic"><use href="#i-gear"/></svg></button>

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -44,6 +44,7 @@ header {
 .dot.ok { background: var(--ok); }
 .dot.err { background: var(--err); }
 .hbtns { display: flex; gap: 8px; }
+.ver { font-size: 10px; color: var(--muted); font-weight: 600; background: var(--card2); border: 1px solid var(--line); padding: 2px 6px; border-radius: 6px; vertical-align: middle; }
 
 .card {
   background: var(--card);

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
-// Service worker — shell offline + notifications push.
-const CACHE = 'pocket-v6';
+// Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
+const CACHE = 'pocket-v7';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {
@@ -8,20 +8,27 @@ self.addEventListener('install', (e) => {
 self.addEventListener('activate', (e) => {
   e.waitUntil(caches.keys().then((ks) => Promise.all(ks.filter((k) => k !== CACHE).map((k) => caches.delete(k)))).then(() => self.clients.claim()));
 });
+
+// Réseau d'abord : on sert toujours la dernière version si en ligne, cache en secours hors-ligne.
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
-  if (url.hostname === 'api.github.com') return; // jamais en cache
-  e.respondWith(caches.match(e.request).then((c) => c || fetch(e.request).catch(() => caches.match('./index.html'))));
+  if (url.hostname === 'api.github.com') return; // jamais intercepté
+  if (e.request.method !== 'GET') return;
+  e.respondWith(
+    fetch(e.request).then((res) => {
+      const copy = res.clone();
+      caches.open(CACHE).then((c) => c.put(e.request, copy)).catch(() => {});
+      return res;
+    }).catch(() => caches.match(e.request).then((c) => c || caches.match('./index.html')))
+  );
 });
 
-// Push : affiche la notification envoyée par le workflow à la fin d'une tâche.
+// Push : notification de fin de tâche.
 self.addEventListener('push', (e) => {
   let data = {};
   try { data = e.data.json(); } catch { data = { title: 'Claude Pocket', body: e.data ? e.data.text() : 'Tâche terminée' }; }
   e.waitUntil(self.registration.showNotification(data.title || 'Claude Pocket', {
-    body: data.body || 'Une tâche est terminée.',
-    icon: './icon.svg', badge: './icon.svg', tag: data.tag || 'pocket',
-    data: { url: data.url || './' },
+    body: data.body || 'Une tâche est terminée.', icon: './icon.svg', badge: './icon.svg', tag: data.tag || 'pocket', data: { url: data.url || './' },
   }));
 });
 self.addEventListener('notificationclick', (e) => {


### PR DESCRIPTION
Corrige le cache figé iOS (network-first), auto-reload, badge version. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch the Pocket service worker to a network-first strategy and introduce app version surfacing and auto-reload on SW updates.

New Features:
- Display the Pocket app version both in the header badge and in the system information panel.

Enhancements:
- Update the service worker to use a network-first fetch strategy with offline fallback and to avoid intercepting non-GET and GitHub API requests.
- Auto-refresh the page when a new service worker takes control to ensure users run the latest version.
- Tweak push notification handling text and metadata without changing core behavior.
- Style a compact version badge in the header.