### PR TITLE
feat(pocket): v8 — light theme, Max Pro UI, token gauges

### DIFF
--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,7 +2,9 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v7';
+const APP_VERSION = 'v8';
+const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
+function estTokens(text) { return Math.round((text || '').length / 4); }
 const CATS = {
   'cat:crm': { label: 'CRM', color: '#3b6fd4' },
   'cat:enrich': { label: 'Enrichissement', color: '#8957e5' },
@@ -124,6 +126,7 @@ function renderHistory() {
   for (const i of items) {
     const cat = issueCat(i) || 'cat:other'; const cm = CATS[cat] || CATS['cat:other'];
     const li = document.createElement('li');
+    li.style.setProperty('--cat', cm.color);
     li.innerHTML = `<span class="t">#${i.number} ${escapeHtml((i.title || '').replace('[Pocket] ', ''))}</span>
       <span class="meta-r"><span class="cat-badge" style="background:${cm.color}">${cm.label}</span>
       <span class="badge ${i.state === 'open' ? 'open' : 'pending'}">${i.state === 'open' ? '●' : '✓'}</span></span>`;
@@ -148,13 +151,16 @@ async function renderRunStatus(run) {
   try { jobs = await gh(`/actions/runs/${run.id}/jobs`); const job = (jobs.jobs || []).find((j) => j.status === 'in_progress') || (jobs.jobs || [])[0]; const cur = job && (job.steps || []).find((s) => s.status === 'in_progress'); if (cur) step = STEP_LABELS[cur.name] || cur.name; } catch {}
   bar.className = 'status-bar running'; bar.textContent = step + '…'; return jobs;
 }
-async function renderMonitor(run, jobs) {
+async function renderMonitor(run, jobs, usage) {
   const el = $('monitor');
+  const u = usage || { tokens: 0, pct: 0 };
   let h = '<div class="kgrid">';
   h += cell('Modèle', 'i-brain', MODEL) + cell('Agent', 'i-robot', 'Claude Pocket');
   h += cell('Statut', 'i-info', run ? (run.status === 'completed' ? (run.conclusion || 'fini') : run.status) : '—');
   h += cell('Durée', 'i-clock', run ? fmtDur(run.run_started_at, run.status === 'completed' ? run.updated_at : null) : '—');
-  h += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Contexte</div><div class="v sm">~200K tokens · session neuve par tâche (le fil de chat sert de mémoire)</div></div></div>`;
+  h += cell('Tokens (estim.)', 'i-brain', '≈ ' + u.tokens.toLocaleString('fr-FR'));
+  h += cell('Contexte', 'i-brain', u.pct.toFixed(1) + '% de 200K');
+  h += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Remplissage du contexte</div><div class="gauge ${u.pct > 80 ? 'warn' : ''}"><i style="width:${Math.min(100, u.pct)}%"></i></div></div></div>`;
   if (!jobs && run && run.status !== 'completed') { try { jobs = await gh(`/actions/runs/${run.id}/jobs`); } catch {} }
   const job = jobs && ((jobs.jobs || []).find((j) => j.name && j.name.includes('pocket')) || (jobs.jobs || [])[0]);
   if (job && job.steps) { h += '<div class="steps">'; for (const s of job.steps.filter((s) => STEP_LABELS[s.name])) { const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : ''); h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}</div>`; } h += '</div>'; }
@@ -172,9 +178,12 @@ function loadDetail(number) {
     try {
       const [issue, comments] = await Promise.all([gh(`/issues/${number}`), gh(`/issues/${number}/comments?per_page=100`)]);
       const approved = (issue.labels || []).map((l) => l.name).includes('approved');
+      const threadText = (issue.body || '') + comments.map((c) => c.body).join('\n');
+      const tokens = estTokens(threadText);
+      const usage = { tokens, pct: Math.min(100, tokens / CTX_WINDOW * 100) };
       const run = await findRun(issue.title);
       const jobs = await renderRunStatus(run);
-      await renderMonitor(run, jobs);
+      await renderMonitor(run, jobs, usage);
       const c = $('comments'); c.innerHTML = '';
       const body = (issue.body || '').split('### Autoriser')[0].replace('### Demande', '').trim();
       if (body) c.appendChild(bubble(connectedLogin || 'toi', body, 'user', issue.created_at));
@@ -219,6 +228,16 @@ async function renderSystem() {
   d.push(cell('Batterie', 'i-info', bat));
   $('system-grid').innerHTML = d.join('');
   $('claude-grid').innerHTML = [cell('Modèle', 'i-brain', MODEL), cell('Version app', 'i-info', APP_VERSION), cell('Exécution', 'i-robot', 'GitHub Actions'), cell('Contexte', 'i-brain', '~200K, neuf/tâche')].join('');
+  // Usage estimé sur la fenêtre 5h (à partir des tâches récentes)
+  const now = Date.now(), WIN = 5 * 3600 * 1000;
+  const recent = (allIssues || []).filter((i) => i.created_at && now - new Date(i.created_at) < WIN);
+  let tok = 0;
+  for (const i of recent) tok += estTokens(i.body) + (i.comments || 0) * 250;
+  const REF = 1000000; // référence indicative pour une session 5h chargée
+  const pct = Math.min(100, tok / REF * 100);
+  $('usage-box').innerHTML =
+    `<div class="kgrid">${cell('Tâches (5h)', 'i-list', recent.length)}${cell('Tokens estim. (5h)', 'i-brain', '≈ ' + tok.toLocaleString('fr-FR'))}</div>` +
+    `<div class="kcell wide" style="margin-top:8px"><div class="k"><svg class="ic"><use href="#i-clock"/></svg>Fenêtre 5h (indicatif /1M)</div><div class="gauge ${pct > 80 ? 'warn' : ''}"><i style="width:${pct}%"></i></div></div>`;
 }
 
 // ── Push ────────────────────────────────────────────────────────────────────
@@ -281,6 +300,7 @@ function applyTheme(t) {
 function init() {
   $('repo').value = LS.repo || 'GaspardCoche/agent-system'; $('pat').value = LS.pat;
   if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
+  $('brand-home').onclick = () => navigate('main');
   $('nav-settings').onclick = () => $('settings').classList.toggle('hidden');
   $('nav-system').onclick = () => navigate('system');
   $('system-back').onclick = () => history.back();

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -37,7 +37,7 @@
   </svg>
 
   <header>
-    <div class="brand"><span class="dot" id="conn-dot"></span> Claude Pocket <span id="ver-badge" class="ver">v7</span></div>
+    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v8</span></button>
     <div class="hbtns">
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
       <button class="icon-btn" id="nav-settings" title="Réglages"><svg class="ic"><use href="#i-gear"/></svg></button>
@@ -73,7 +73,9 @@
     <div id="system-grid" class="kgrid"></div>
     <h2 style="margin-top:18px"><svg class="ic"><use href="#i-brain"/></svg> Claude</h2>
     <div id="claude-grid" class="kgrid"></div>
-    <p class="hint">Claude s'exécute sur les serveurs GitHub Actions, pas sur ton téléphone — le CPU/GPU réel du runner n'est pas exposé. Le suivi en temps réel se fait via l'état du run et les étapes (voir une tâche).</p>
+    <h2 style="margin-top:18px"><svg class="ic"><use href="#i-clock"/></svg> Usage (estimation)</h2>
+    <div id="usage-box"></div>
+    <p class="hint">Estimation (longueur des échanges ÷ 4 ≈ tokens). Le quota réel des sessions 5h d'Anthropic n'est pas exposé par l'API ; ces valeurs servent d'ordre de grandeur. Claude tourne sur GitHub Actions (cloud) — le CPU/GPU du runner n'est pas exposé.</p>
   </section>
 
   <!-- ── Composer ── -->

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -1,95 +1,79 @@
+/* ── Thèmes ────────────────────────────────────────────────────────────── */
 :root {
-  --bg: #0a0e16;
-  --card: #121826;
-  --card2: #1a2233;
-  --line: #232d40;
-  --text: #e7edf5;
-  --muted: #8a97ab;
-  --accent: #6aa3ff;
-  --accent2: #3b6fd4;
-  --ok: #3fb950;
-  --warn: #d29922;
-  --err: #f85149;
-  --radius: 16px;
+  --bg: #0a0e16; --card: #121826; --card2: #1a2233; --line: #232d40;
+  --text: #e7edf5; --muted: #8a97ab; --accent: #6aa3ff; --accent2: #3b6fd4;
+  --ok: #3fb950; --warn: #d29922; --err: #f85149;
+  --bubble-user: #15294a; --accent-soft: #122039;
+  --shadow: 0 6px 20px rgba(0,0,0,.28);
+  --radius: 18px;
 }
-/* Thème clair : explicite, ou auto via préférence système */
 :root[data-theme="light"] {
-  --bg: #eef1f7; --card: #ffffff; --card2: #f1f4f9; --line: #d9e0ec;
-  --text: #18202e; --muted: #5b6781; --accent: #2f6fe0; --accent2: #2056bd;
+  --bg: #eef1f7; --card: #ffffff; --card2: #f2f5fa; --line: #dce3ef;
+  --text: #16202e; --muted: #5d6982; --accent: #2f6fe0; --accent2: #1f55bd;
+  --bubble-user: #dce9fd; --accent-soft: #e9f1ff; --shadow: 0 6px 18px rgba(40,60,100,.10);
 }
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
-    --bg: #eef1f7; --card: #ffffff; --card2: #f1f4f9; --line: #d9e0ec;
-    --text: #18202e; --muted: #5b6781; --accent: #2f6fe0; --accent2: #2056bd;
+    --bg: #eef1f7; --card: #ffffff; --card2: #f2f5fa; --line: #dce3ef;
+    --text: #16202e; --muted: #5d6982; --accent: #2f6fe0; --accent2: #1f55bd;
+    --bubble-user: #dce9fd; --accent-soft: #e9f1ff; --shadow: 0 6px 18px rgba(40,60,100,.10);
   }
 }
+
 * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
 html, body { margin: 0; background: var(--bg); }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
-  color: var(--text);
-  padding: env(safe-area-inset-top) 14px calc(env(safe-area-inset-bottom) + 28px);
-  max-width: 680px; margin: 0 auto;
-  -webkit-font-smoothing: antialiased;
+  color: var(--text); padding: env(safe-area-inset-top) 14px calc(env(safe-area-inset-bottom) + 28px);
+  max-width: 680px; margin: 0 auto; -webkit-font-smoothing: antialiased;
+  transition: background .25s, color .25s;
 }
 .ic { width: 18px; height: 18px; display: inline-block; vertical-align: -3px; }
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
 header {
   position: sticky; top: 0; z-index: 10;
   display: flex; align-items: center; justify-content: space-between;
-  padding: 16px 4px 12px; margin-bottom: 6px;
-  background: linear-gradient(var(--bg) 70%, transparent);
+  padding: 16px 4px 12px; margin-bottom: 8px;
+  background: linear-gradient(var(--bg) 72%, transparent);
 }
-.brand { font-size: 18px; font-weight: 700; letter-spacing: -.01em; display: flex; align-items: center; gap: 9px; }
-.dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); box-shadow: 0 0 0 0 rgba(0,0,0,0); }
-.dot.ok { background: var(--ok); }
-.dot.err { background: var(--err); }
+.brand { font-size: 18px; font-weight: 750; letter-spacing: -.015em; display: flex; align-items: center; gap: 9px; cursor: pointer; background: none; color: var(--text); padding: 0; }
+.brand .logo { width: 26px; height: 26px; border-radius: 8px; flex: 0 0 auto; }
+.dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); }
+.dot.ok { background: var(--ok); } .dot.err { background: var(--err); }
+.ver { font-size: 10px; color: var(--muted); font-weight: 600; background: var(--card2); border: 1px solid var(--line); padding: 2px 6px; border-radius: 6px; }
 .hbtns { display: flex; gap: 8px; }
-.ver { font-size: 10px; color: var(--muted); font-weight: 600; background: var(--card2); border: 1px solid var(--line); padding: 2px 6px; border-radius: 6px; vertical-align: middle; }
 
-.card {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  padding: 16px; margin-bottom: 14px;
-}
-h2 { font-size: 13px; margin: 0 0 14px; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700; display: flex; align-items: center; gap: 8px; }
+/* ── Cartes ─────────────────────────────────────────────────────────────── */
+.card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px; margin-bottom: 14px; box-shadow: var(--shadow); }
+h2 { font-size: 12.5px; margin: 0 0 14px; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700; display: flex; align-items: center; gap: 8px; }
 h2 .ic { width: 15px; height: 15px; color: var(--accent); }
 
 label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 12px; }
 label small { font-weight: 400; opacity: .65; }
 input[type=text], input[type=password], textarea {
-  width: 100%; margin-top: 6px; padding: 13px;
-  background: var(--card2); border: 1px solid var(--line); border-radius: 11px;
-  color: var(--text); font-size: 16px; font-family: inherit;
+  width: 100%; margin-top: 6px; padding: 13px; background: var(--card2); border: 1px solid var(--line);
+  border-radius: 12px; color: var(--text); font-size: 16px; font-family: inherit; transition: border-color .15s;
 }
-input:focus, textarea:focus { outline: none; border-color: var(--accent2); }
+input:focus, textarea:focus { outline: none; border-color: var(--accent); }
 textarea { resize: vertical; line-height: 1.45; }
 .textarea-wrap { position: relative; }
 .textarea-wrap .mic { position: absolute; right: 8px; bottom: 8px; }
 
 .row { display: flex; gap: 12px; align-items: center; justify-content: space-between; }
-.toggle { display: flex; align-items: center; gap: 9px; margin: 4px 0 12px; color: var(--text); }
+.toggle { display: flex; align-items: center; gap: 9px; margin: 6px 0 12px; color: var(--text); }
 .toggle input { width: 22px; height: 22px; accent-color: var(--accent2); }
 
+/* ── Boutons ────────────────────────────────────────────────────────────── */
 button { cursor: pointer; font-family: inherit; border: none; }
-.primary {
-  width: 100%; padding: 14px; border-radius: 12px; font-size: 15px; font-weight: 650;
-  color: #fff; background: linear-gradient(135deg, var(--accent), var(--accent2));
-  display: flex; align-items: center; justify-content: center; gap: 8px;
-}
-.primary:active { filter: brightness(1.12); }
+.primary { width: 100%; padding: 14px; border-radius: 13px; font-size: 15px; font-weight: 650; color: #fff; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; gap: 8px; box-shadow: 0 4px 14px rgba(59,111,212,.35); transition: filter .12s, transform .08s; }
+.primary:active { filter: brightness(1.1); transform: scale(.99); }
 .primary.big { padding: 16px; font-size: 16px; margin-top: 8px; }
 .primary .ic { color: #fff; }
-.ghost {
-  width: 100%; margin-top: 12px; padding: 12px; border-radius: 11px;
-  background: var(--card2); color: var(--text); border: 1px solid var(--line);
-  font-size: 14px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 8px;
-}
+.ghost { width: 100%; margin-top: 12px; padding: 12px; border-radius: 12px; background: var(--card2); color: var(--text); border: 1px solid var(--line); font-size: 14px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 8px; }
 .ghost .ic { color: var(--accent); }
-.icon-btn {
-  background: var(--card2); border: 1px solid var(--line); border-radius: 11px;
-  color: var(--text); width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center;
-}
+.icon-btn { background: var(--card2); border: 1px solid var(--line); border-radius: 12px; color: var(--text); width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; transition: background .12s; }
+.icon-btn:active { background: var(--line); }
 .icon-btn .ic { color: var(--text); }
 .icon-btn.mic.live { background: #4a1d1d; border-color: var(--err); }
 .icon-btn.mic.live .ic { color: #ff8a80; }
@@ -101,79 +85,83 @@ button { cursor: pointer; font-family: inherit; border: none; }
 .msg { font-size: 13px; margin: 10px 0 0; min-height: 16px; line-height: 1.5; white-space: pre-wrap; }
 .msg.ok { color: var(--ok); } .msg.err { color: var(--err); }
 
-/* chips suggestions */
-.chips { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 4px; }
-.chip { font-size: 12.5px; padding: 7px 12px; border-radius: 999px; background: var(--card2); color: var(--accent); border: 1px solid var(--line); font-weight: 600; }
-.chip:active { background: var(--accent2); color: #fff; }
+/* segmented control */
+.seg { display: flex; margin-top: 6px; background: var(--card2); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
+.seg button { flex: 1; padding: 10px; background: transparent; color: var(--muted); font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 5px; }
+.seg button.active { background: var(--accent2); color: #fff; }
+.seg button .ic { width: 14px; height: 14px; }
 
-/* historique */
+/* chips */
+.chips { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0 4px; }
+.chip { font-size: 12.5px; padding: 8px 13px; border-radius: 999px; background: var(--card2); color: var(--accent); border: 1px solid var(--line); font-weight: 600; transition: background .12s; }
+.chip:active, .chip.active { background: var(--accent2); color: #fff; }
+
+/* fichiers */
+.file-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.file-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12.5px; background: var(--card2); border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px; }
+.file-row .fx { color: var(--text); font-weight: 600; }
+.file-row button { background: none; color: var(--err); font-size: 18px; line-height: 1; padding: 0 4px; }
+
+/* ── Historique ─────────────────────────────────────────────────────────── */
 ul { list-style: none; padding: 0; margin: 0; }
 #history-list li {
-  padding: 13px; background: var(--card2); border: 1px solid var(--line); border-radius: 12px;
-  margin-bottom: 8px; display: flex; justify-content: space-between; align-items: center; gap: 10px;
+  padding: 13px 14px; background: var(--card2); border: 1px solid var(--line); border-radius: 13px;
+  margin-bottom: 9px; display: flex; justify-content: space-between; align-items: center; gap: 10px;
+  border-left: 3px solid var(--cat, var(--line)); transition: transform .08s;
 }
-#history-list li .t { font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.badge { font-size: 11px; padding: 4px 9px; border-radius: 999px; white-space: nowrap; font-weight: 600; }
-.badge.open { background: #14301d; color: var(--ok); }
-.badge.pending { background: #2a3142; color: var(--muted); }
+#history-list li:active { transform: scale(.99); }
+#history-list li .t { font-size: 14.5px; font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+.badge { font-size: 11px; padding: 4px 9px; border-radius: 999px; white-space: nowrap; font-weight: 700; }
+.badge.open { background: rgba(63,185,80,.16); color: var(--ok); }
+.badge.pending { background: var(--card); color: var(--muted); border: 1px solid var(--line); }
+.cat-badge { font-size: 10.5px; padding: 3px 9px; border-radius: 999px; font-weight: 700; color: #fff; white-space: nowrap; }
+.hgroup { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; margin: 14px 0 8px; }
 
-/* console / statut */
-.status-bar { font-size: 13.5px; font-weight: 650; padding: 12px 14px; border-radius: 12px; margin-bottom: 12px; border: 1px solid var(--line); background: var(--card2); color: var(--text); display: flex; align-items: center; gap: 9px; }
+/* ── Console / monitoring ───────────────────────────────────────────────── */
+.status-bar { font-size: 13.5px; font-weight: 650; padding: 12px 14px; border-radius: 13px; margin-bottom: 12px; border: 1px solid var(--line); background: var(--card2); color: var(--text); display: flex; align-items: center; gap: 9px; }
 .status-bar.idle, .status-bar.queued { color: var(--muted); }
-.status-bar.running { color: var(--accent); border-color: #2c4a7a; background: #11203a; }
+.status-bar.running { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
 .status-bar.running::before { content: ''; width: 9px; height: 9px; border-radius: 50%; background: var(--accent); animation: pulse 1s infinite; flex: 0 0 auto; }
-.status-bar.ok { color: var(--ok); border-color: #16361f; background: #0e2415; }
-.status-bar.err { color: var(--warn); border-color: #3a2a17; background: #241a0d; }
-@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+.status-bar.ok { color: var(--ok); border-color: rgba(63,185,80,.4); background: rgba(63,185,80,.10); }
+.status-bar.err { color: var(--warn); border-color: rgba(210,153,34,.4); background: rgba(210,153,34,.10); }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
 
-/* monitoring grid */
 .monitor { margin-bottom: 14px; }
 .kgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-.kcell { background: var(--card2); border: 1px solid var(--line); border-radius: 11px; padding: 11px 12px; }
+.kcell { background: var(--card2); border: 1px solid var(--line); border-radius: 12px; padding: 11px 12px; }
 .kcell .k { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; display: flex; align-items: center; gap: 6px; }
 .kcell .k .ic { width: 13px; height: 13px; color: var(--muted); }
 .kcell .v { font-size: 15px; font-weight: 700; margin-top: 4px; }
-.kcell.wide { grid-column: 1 / -1; }
 .kcell .v.sm { font-size: 13px; font-weight: 600; }
+.kcell.wide { grid-column: 1 / -1; }
+
+/* jauge (contexte / tokens) */
+.gauge { height: 8px; background: var(--card2); border: 1px solid var(--line); border-radius: 999px; overflow: hidden; margin-top: 7px; }
+.gauge > i { display: block; height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent2)); border-radius: 999px; transition: width .4s; }
+.gauge.warn > i { background: linear-gradient(90deg, var(--warn), var(--err)); }
 
 /* timeline étapes */
-.steps { margin-top: 10px; }
+.steps { margin-top: 12px; }
 .step { display: flex; align-items: center; gap: 9px; font-size: 13px; padding: 5px 0; color: var(--muted); }
 .step .sdot { width: 7px; height: 7px; border-radius: 50%; background: var(--line); flex: 0 0 auto; }
 .step.done { color: var(--text); } .step.done .sdot { background: var(--ok); }
 .step.cur { color: var(--accent); } .step.cur .sdot { background: var(--accent); animation: pulse 1s infinite; }
 
-/* commentaires */
-.comment { background: var(--card2); border: 1px solid var(--line); border-radius: 12px; padding: 13px; margin-bottom: 10px; font-size: 14px; white-space: pre-wrap; word-break: break-word; line-height: 1.5; }
-.comment.progress { background: #11203a; border-color: #2c4a7a; color: var(--accent); font-weight: 600; }
+/* ── Chat ───────────────────────────────────────────────────────────────── */
+#comments { display: flex; flex-direction: column; gap: 9px; }
+.comment { border: 1px solid var(--line); border-radius: 15px; padding: 12px 14px; font-size: 14px; white-space: pre-wrap; word-break: break-word; line-height: 1.5; max-width: 88%; }
+.comment.assistant { background: var(--card2); align-self: flex-start; border-bottom-left-radius: 5px; }
+.comment.user { background: var(--bubble-user); border-color: var(--accent2); align-self: flex-end; border-bottom-right-radius: 5px; }
+.comment.progress { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); font-weight: 600; align-self: flex-start; }
 .comment .who { font-size: 11px; color: var(--muted); margin-bottom: 6px; }
+.comment.user .who { color: var(--accent); }
 .empty { color: var(--muted); font-size: 13px; }
 
-/* chat bulles */
-.comment.user { background: linear-gradient(135deg, #16263f, #1a2740); border-color: #2c4a7a; margin-left: 28px; }
-.comment.assistant { margin-right: 28px; }
-.comment.user .who { color: var(--accent); }
-
-/* chatbar */
-.chatbar { display: flex; gap: 8px; align-items: flex-end; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--line); }
-.chatbar textarea { flex: 1; margin: 0; min-height: 44px; max-height: 140px; }
-.chatbar .icon-btn { width: 46px; height: 46px; flex: 0 0 auto; background: linear-gradient(135deg, var(--accent), var(--accent2)); border: none; }
+.chatbar { display: flex; gap: 8px; align-items: flex-end; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line); }
+.chatbar textarea { flex: 1; margin: 0; min-height: 46px; max-height: 140px; border-radius: 14px; }
+.chatbar .icon-btn { width: 48px; height: 48px; flex: 0 0 auto; background: linear-gradient(135deg, var(--accent), var(--accent2)); border: none; box-shadow: 0 4px 12px rgba(59,111,212,.3); }
 .chatbar .icon-btn .ic { color: #fff; }
 
-/* catégories */
-.cat-badge { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; font-weight: 700; color: #fff; white-space: nowrap; }
-.chip.active { background: var(--accent2); color: #fff; }
-.hgroup { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; margin: 14px 0 8px; }
-#history-list li .meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
-
-/* segmented control (thème) */
-.seg { display: flex; gap: 0; margin-top: 6px; background: var(--card2); border: 1px solid var(--line); border-radius: 11px; overflow: hidden; }
-.seg button { flex: 1; padding: 10px; background: transparent; color: var(--muted); font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 5px; }
-.seg button.active { background: var(--accent2); color: #fff; }
-.seg button .ic { width: 14px; height: 14px; }
-
-/* fichiers joints */
-.file-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
-.file-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12.5px; background: var(--card2); border: 1px solid var(--line); border-radius: 9px; padding: 8px 10px; }
-.file-row .fx { color: var(--muted); font-weight: 600; }
-.file-row button { background: none; color: var(--err); font-size: 16px; line-height: 1; padding: 0 4px; }
+section { animation: fade .22s ease; }
+@keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v7';
+const CACHE = 'pocket-v8';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
Thème clair corrigé, UI polish, logo cliquable, estimation tokens/contexte + fenêtre 5h. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce Claude Pocket v8 with a refreshed UI, improved theming, and estimated token/context usage monitoring.

New Features:
- Add per-thread estimated token usage and context fill gauges in the run monitor.
- Add a 5-hour window usage estimation section on the system page, including task count and token estimates.
- Make the app brand/logo in the header clickable to return to the main view.

Enhancements:
- Refine dark and light theme palettes, spacing, radii, and shadows for cards, buttons, and inputs.
- Redesign chat bubbles, history list items, status bar, and chips for a more polished, Max Pro-style UI.
- Display category colors on history items via left border accents and updated badges.
- Update monitoring grid layout and labels to surface model, agent, status, duration, and token data more clearly.

Deployment:
- Bump the app and service worker cache versions from v7 to v8.