### PR TITLE
feat(pocket): v9 — agentic modes + deeper live visibility

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -164,7 +164,10 @@ jobs:
             Si une app pertinente manque de secret, dis-le proprement et propose une alternative — ne plante pas.
 
             === MÉTHODE ===
-            1. Comprends l'intention. Si la demande contient une section **"### Fichiers joints"**, lis chaque fichier listé avec `cat <chemin>` (ils sont dans le checkout du repo) AVANT d'agir — ex : un CSV de contacts à enrichir/analyser. Si un "Workflow" précis (≠ auto) est indiqué, tu peux lire son playbook : `cat agent_prompts/workflows/<workflow>.md`. Sinon, raisonne librement.
+            1. Comprends l'intention.
+               - Si la demande contient une section **"### Mode"** avec un slug ≠ `auto` : `cat pocket-modes/<slug>.json` et **suis STRICTEMENT le champ `instructions`** de ce mode (c'est un agent personnalisé créé par Gaspard), par-dessus les garde-fous.
+               - Si la demande contient **"### Fichiers joints"**, lis chaque fichier avec `cat <chemin>` AVANT d'agir.
+               - Si un "Workflow" précis (≠ auto) est indiqué, tu peux lire `cat agent_prompts/workflows/<workflow>.md`. Sinon, raisonne librement.
             2. Choisis l'app et agis. **Narre tes étapes** : poste un court commentaire de progression à chaque étape clé (ex : "🔎 Je interroge HubSpot…", "📊 J'analyse…") — c'est ce que Gaspard suit en direct dans son app.
             3. **Lecture par défaut.** Écriture/action coûteuse (HubSpot write, FullEnrich --confirm, PhantomBuster launch, Lemlist add/send) UNIQUEMENT si `approved` = true ET demandée ET dans les garde-fous. Sinon, poste un PREVIEW de ce que tu ferais et demande le label `approved`.
             4. Poste le RÉSULTAT FINAL en commentaire (clair, prêt à copier, même langue que la demande) :

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,9 +2,11 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v8';
+const APP_VERSION = 'v9';
 const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
 function estTokens(text) { return Math.round((text || '').length / 4); }
+function slugify(s) { return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40); }
+function decodeB64(c) { try { return decodeURIComponent(escape(atob((c || '').replace(/\s/g, '')))); } catch { return ''; } }
 const CATS = {
   'cat:crm': { label: 'CRM', color: '#3b6fd4' },
   'cat:enrich': { label: 'Enrichissement', color: '#8957e5' },
@@ -25,6 +27,7 @@ const LS = {
 };
 const $ = (id) => document.getElementById(id);
 let pollTimer = null, allIssues = [], currentFilter = 'all', connectedLogin = '', detailNum = null, attachedFiles = [];
+let allModes = [], selectedMode = 'auto', editingMode = null;
 
 // ── API GitHub ──────────────────────────────────────────────────────────────
 async function gh(path, opts = {}) {
@@ -97,7 +100,8 @@ async function dispatch() {
       msg.textContent = 'Envoi…';
     }
     const title = '[Pocket] ' + demande.slice(0, 60).replace(/\n/g, ' ');
-    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c) + attachNote, labels: ['pocket'] }) });
+    const modeNote = '\n\n### Mode\n\n' + (selectedMode || 'auto');
+    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c) + modeNote + attachNote, labels: ['pocket'] }) });
     $('demande').value = ''; $('conditions').value = ''; $('write-allowed').checked = false; $('conditions-wrap').classList.add('hidden');
     attachedFiles = []; renderFileList();
     msg.className = 'msg ok'; msg.textContent = `Tâche #${issue.number} envoyée.`;
@@ -135,6 +139,71 @@ function renderHistory() {
   }
 }
 
+// ── Modes agentiques (CRUD via repo) ────────────────────────────────────────
+async function loadModes() {
+  try {
+    const items = await gh('/contents/pocket-modes');
+    const files = (Array.isArray(items) ? items : []).filter((f) => f.name.endsWith('.json'));
+    const out = [];
+    for (const f of files) {
+      try { const c = await gh('/contents/' + f.path); const o = JSON.parse(decodeB64(c.content)); o._sha = c.sha; out.push(o); } catch {}
+    }
+    allModes = out.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  } catch { allModes = []; }
+  renderModeChips();
+}
+function renderModeChips() {
+  const el = $('mode-chips'); if (!el) return; el.innerHTML = '';
+  const mk = (slug, label) => { const b = document.createElement('button'); b.className = 'chip' + (selectedMode === slug ? ' active' : ''); b.textContent = label; b.onclick = () => { selectedMode = slug; renderModeChips(); }; return b; };
+  el.appendChild(mk('auto', '⚡ Généraliste'));
+  for (const m of allModes) el.appendChild(mk(m.slug, m.name));
+}
+function renderModes() {
+  const ul = $('modes-list'); ul.innerHTML = '';
+  if (!allModes.length) { ul.innerHTML = '<li class="empty">Aucun mode pour l\'instant. Crée ton premier agent.</li>'; return; }
+  for (const m of allModes) {
+    const cm = CATS[m.category] || CATS['cat:other'];
+    const li = document.createElement('li'); li.style.setProperty('--cat', cm.color);
+    li.innerHTML = `<div class="mh"><div><div class="mn">${escapeHtml(m.name)}</div><div class="md">${escapeHtml(m.description || '')}</div></div><div class="actions"><button class="edit">Éditer</button></div></div>`;
+    li.querySelector('.edit').onclick = () => openModeEditor(m);
+    ul.appendChild(li);
+  }
+}
+function openModeEditor(mode) {
+  editingMode = mode || null;
+  $('mode-editor').classList.remove('hidden');
+  $('mode-name').value = mode ? mode.name : '';
+  $('mode-cat').value = mode ? mode.category : 'cat:other';
+  $('mode-desc').value = mode ? mode.description : '';
+  $('mode-instr').value = mode ? mode.instructions : '';
+  $('mode-delete').classList.toggle('hidden', !mode);
+  $('mode-msg').textContent = '';
+  $('mode-editor').scrollIntoView({ behavior: 'smooth' });
+}
+async function saveMode() {
+  const name = $('mode-name').value.trim(), instr = $('mode-instr').value.trim(), m = $('mode-msg');
+  if (!name || !instr) { m.className = 'msg err'; m.textContent = 'Nom et instructions requis.'; return; }
+  const slug = editingMode ? editingMode.slug : slugify(name);
+  const obj = { name, slug, category: $('mode-cat').value, description: $('mode-desc').value.trim(), instructions: instr, created: editingMode ? editingMode.created : Date.now() };
+  m.className = 'msg'; m.textContent = 'Déploiement…';
+  try {
+    let sha = editingMode ? editingMode._sha : undefined;
+    if (!sha) { try { sha = (await gh('/contents/pocket-modes/' + slug + '.json')).sha; } catch {} }
+    await gh('/contents/pocket-modes/' + slug + '.json', { method: 'PUT', body: JSON.stringify({ message: 'pocket: mode ' + slug, content: b64(JSON.stringify(obj, null, 2)), sha }) });
+    m.className = 'msg ok'; m.textContent = '✅ Mode déployé — utilisable au lancement d\'une tâche.';
+    $('mode-editor').classList.add('hidden');
+    await loadModes(); renderModes();
+  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
+}
+async function deleteMode() {
+  if (!editingMode) return; const m = $('mode-msg'); m.className = 'msg'; m.textContent = 'Suppression…';
+  try {
+    await gh('/contents/pocket-modes/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: delete mode ' + editingMode.slug, sha: editingMode._sha }) });
+    if (selectedMode === editingMode.slug) selectedMode = 'auto';
+    $('mode-editor').classList.add('hidden'); await loadModes(); renderModes();
+  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
+}
+
 // ── Monitoring run ──────────────────────────────────────────────────────────
 const STEP_LABELS = { 'Set up job': 'Préparation', 'Run actions/checkout@v4': 'Récupération du code', 'Install MCP servers': 'Installation des outils', 'Run actions/setup-python@v5': 'Préparation Python', 'Write task to disk': 'Lecture de la demande', 'Write MCP config with secrets': 'Connexion aux apps', 'Build claude_args': 'Configuration', 'Run Claude Pocket': 'Claude travaille', 'Notify (push)': 'Notification' };
 async function findRun(title) {
@@ -163,7 +232,15 @@ async function renderMonitor(run, jobs, usage) {
   h += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Remplissage du contexte</div><div class="gauge ${u.pct > 80 ? 'warn' : ''}"><i style="width:${Math.min(100, u.pct)}%"></i></div></div></div>`;
   if (!jobs && run && run.status !== 'completed') { try { jobs = await gh(`/actions/runs/${run.id}/jobs`); } catch {} }
   const job = jobs && ((jobs.jobs || []).find((j) => j.name && j.name.includes('pocket')) || (jobs.jobs || [])[0]);
-  if (job && job.steps) { h += '<div class="steps">'; for (const s of job.steps.filter((s) => STEP_LABELS[s.name])) { const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : ''); h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}</div>`; } h += '</div>'; }
+  if (job && job.steps) {
+    h += '<div class="steps">';
+    for (const s of job.steps.filter((s) => STEP_LABELS[s.name])) {
+      const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : '');
+      const dur = (s.started_at && s.completed_at) ? Math.max(1, Math.round((new Date(s.completed_at) - new Date(s.started_at)) / 1000)) + 's' : '';
+      h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}${dur ? '<span style="margin-left:auto;color:var(--muted);font-size:11px">' + dur + '</span>' : ''}</div>`;
+    }
+    h += '</div>';
+  }
   el.innerHTML = h;
 }
 
@@ -184,6 +261,12 @@ function loadDetail(number) {
       const run = await findRun(issue.title);
       const jobs = await renderRunStatus(run);
       await renderMonitor(run, jobs, usage);
+      // Activité en direct (dernier message de progression) + lien logs bruts
+      const prog = comments.filter((cm) => cm.user.type !== 'User' && /^▶️|^🔎|^📊|^🧠|^⏳|m'en occupe/i.test(cm.body.trim()));
+      const la = $('live-activity');
+      if (run && run.status !== 'completed' && prog.length) { la.classList.remove('hidden'); la.textContent = prog[prog.length - 1].body.split('\n')[0].slice(0, 130); }
+      else la.classList.add('hidden');
+      const rl = $('run-link'); if (run && run.html_url) { rl.href = run.html_url; rl.classList.remove('hidden'); } else rl.classList.add('hidden');
       const c = $('comments'); c.innerHTML = '';
       const body = (issue.body || '').split('### Autoriser')[0].replace('### Demande', '').trim();
       if (body) c.appendChild(bubble(connectedLogin || 'toi', body, 'user', issue.created_at));
@@ -261,9 +344,12 @@ function applyView(view) {
   const isDetail = view.startsWith('detail:');
   $('detail').classList.toggle('hidden', !isDetail);
   $('system').classList.toggle('hidden', view !== 'system');
-  for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', isDetail || view === 'system');
+  $('modes').classList.toggle('hidden', view !== 'modes');
+  const isMain = !isDetail && view !== 'system' && view !== 'modes';
+  for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', !isMain);
   if (!isDetail) stopPoll();
   if (view === 'system') renderSystem();
+  else if (view === 'modes') { renderModes(); $('mode-editor').classList.add('hidden'); }
   else if (isDetail) loadDetail(parseInt(view.split(':')[1], 10));
   else { detailNum = null; loadHistory(); }
   window.scrollTo(0, 0);
@@ -303,12 +389,17 @@ function init() {
   $('brand-home').onclick = () => navigate('main');
   $('nav-settings').onclick = () => $('settings').classList.toggle('hidden');
   $('nav-system').onclick = () => navigate('system');
+  $('nav-modes').onclick = () => navigate('modes');
+  $('modes-back').onclick = () => history.back();
+  $('mode-new').onclick = () => openModeEditor(null);
+  $('mode-save').onclick = saveMode;
+  $('mode-delete').onclick = deleteMode;
   $('system-back').onclick = () => history.back();
   $('back').onclick = () => history.back();
   $('save-settings').onclick = async () => {
     LS.repo = $('repo').value.trim(); LS.pat = $('pat').value.trim();
     const m = $('settings-msg'); m.className = 'msg'; m.textContent = 'Test…';
-    try { const r = await testConn(false); m.className = 'msg ok'; m.textContent = `Connecté à ${r.full_name}${connectedLogin ? ' · ' + connectedLogin : ''}`; loadHistory(); setTimeout(() => $('settings').classList.add('hidden'), 1400); }
+    try { const r = await testConn(false); m.className = 'msg ok'; m.textContent = `Connecté à ${r.full_name}${connectedLogin ? ' · ' + connectedLogin : ''}`; loadHistory(); loadModes(); setTimeout(() => $('settings').classList.add('hidden'), 1400); }
     catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
   };
   $('enable-push').onclick = enablePush;
@@ -329,7 +420,7 @@ function init() {
 
   setupMic();
   history.replaceState({ view: 'main' }, '', '#main');
-  if (LS.repo && LS.pat) { testConn(true).then(loadHistory); } else { renderHistory(); }
+  if (LS.repo && LS.pat) { testConn(true).then(() => { loadHistory(); loadModes(); }); } else { renderHistory(); }
   if ('serviceWorker' in navigator) {
     let refreshing = false;
     navigator.serviceWorker.addEventListener('controllerchange', () => { if (refreshing) return; refreshing = true; location.reload(); });

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -39,6 +39,7 @@
   <header>
     <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v8</span></button>
     <div class="hbtns">
+      <button class="icon-btn" id="nav-modes" title="Modes agentiques"><svg class="ic"><use href="#i-robot"/></svg></button>
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
       <button class="icon-btn" id="nav-settings" title="Réglages"><svg class="ic"><use href="#i-gear"/></svg></button>
     </div>
@@ -78,9 +79,40 @@
     <p class="hint">Estimation (longueur des échanges ÷ 4 ≈ tokens). Le quota réel des sessions 5h d'Anthropic n'est pas exposé par l'API ; ces valeurs servent d'ordre de grandeur. Claude tourne sur GitHub Actions (cloud) — le CPU/GPU du runner n'est pas exposé.</p>
   </section>
 
+  <!-- ── Modes agentiques ── -->
+  <section id="modes" class="card hidden">
+    <button class="link-btn" id="modes-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
+    <h2><svg class="ic"><use href="#i-robot"/></svg> Modes agentiques</h2>
+    <p class="hint" style="margin-top:0">Crée tes propres agents : un nom, une catégorie et des instructions. Ils deviennent sélectionnables au lancement d'une tâche.</p>
+    <button id="mode-new" class="primary" style="margin:12px 0"><svg class="ic"><use href="#i-plus"/></svg> Nouveau mode</button>
+    <ul id="modes-list"></ul>
+    <div id="mode-editor" class="hidden" style="margin-top:14px;border-top:1px solid var(--line);padding-top:14px">
+      <label>Nom <input id="mode-name" type="text" placeholder="Ex : Veille concurrent" /></label>
+      <label>Catégorie
+        <select id="mode-cat">
+          <option value="cat:crm">CRM</option>
+          <option value="cat:web">Web</option>
+          <option value="cat:enrich">Enrichissement</option>
+          <option value="cat:outreach">Outreach</option>
+          <option value="cat:vault">Vault</option>
+          <option value="cat:code">Code</option>
+          <option value="cat:other">Autre</option>
+        </select>
+      </label>
+      <label>Description <input id="mode-desc" type="text" placeholder="À quoi sert cet agent" /></label>
+      <label>Instructions (le « cerveau » de l'agent)
+        <textarea id="mode-instr" rows="6" placeholder="Tu es un agent qui… Décris précisément sa mission, ses étapes, ses limites."></textarea>
+      </label>
+      <button id="mode-save" class="primary"><svg class="ic"><use href="#i-check"/></svg> Déployer le mode</button>
+      <button id="mode-delete" class="ghost hidden">Supprimer ce mode</button>
+      <p id="mode-msg" class="msg"></p>
+    </div>
+  </section>
+
   <!-- ── Composer ── -->
   <section id="composer" class="card">
     <h2><svg class="ic"><use href="#i-send"/></svg> Nouvelle tâche</h2>
+    <div class="chips" id="mode-chips"></div>
     <div class="textarea-wrap">
       <textarea id="demande" rows="4" placeholder="Décris ta demande en langage naturel… (ex : combien de leads en France ?)"></textarea>
       <button id="mic" class="icon-btn mic" title="Dicter"><svg class="ic"><use href="#i-mic"/></svg></button>
@@ -116,7 +148,9 @@
     <button class="link-btn" id="back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
     <h2 id="detail-title">Tâche</h2>
     <div id="run-status" class="status-bar idle">Chargement…</div>
+    <div id="live-activity" class="live-activity hidden"></div>
     <div id="monitor" class="monitor"></div>
+    <a id="run-link" class="run-link hidden" target="_blank" rel="noopener">Voir les logs détaillés ↗</a>
     <div id="comments"></div>
     <button id="approve" class="primary hidden"><svg class="ic"><use href="#i-check"/></svg> Approuver l'écriture</button>
     <p id="detail-msg" class="msg"></p>

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -163,5 +163,18 @@ ul { list-style: none; padding: 0; margin: 0; }
 .chatbar .icon-btn { width: 48px; height: 48px; flex: 0 0 auto; background: linear-gradient(135deg, var(--accent), var(--accent2)); border: none; box-shadow: 0 4px 12px rgba(59,111,212,.3); }
 .chatbar .icon-btn .ic { color: #fff; }
 
+/* activité live + lien logs */
+.live-activity { font-size: 13.5px; font-weight: 600; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent); border-radius: 13px; padding: 11px 13px; margin-bottom: 12px; display: flex; align-items: center; gap: 10px; }
+.live-activity::before { content: ''; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: pulse 1s infinite; flex: 0 0 auto; }
+.run-link { display: inline-block; font-size: 12.5px; color: var(--muted); margin: 0 0 12px; text-decoration: none; }
+
+/* modes */
+#modes-list li { padding: 13px 14px; background: var(--card2); border: 1px solid var(--line); border-radius: 13px; margin-bottom: 9px; border-left: 3px solid var(--cat, var(--accent)); }
+#modes-list li .mh { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+#modes-list li .mn { font-size: 14.5px; font-weight: 650; }
+#modes-list li .md { font-size: 12.5px; color: var(--muted); margin-top: 4px; line-height: 1.4; }
+#modes-list li .actions { display: flex; gap: 6px; flex: 0 0 auto; }
+#modes-list li .actions button { font-size: 12px; padding: 5px 10px; border-radius: 8px; background: var(--card); border: 1px solid var(--line); color: var(--accent); font-weight: 600; }
+
 section { animation: fade .22s ease; }
 @keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v8';
+const CACHE = 'pocket-v9';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {

--- a/pocket-modes/audit-crm.json
+++ b/pocket-modes/audit-crm.json
@@ -1,0 +1,8 @@
+{
+  "name": "Audit CRM express",
+  "slug": "audit-crm",
+  "category": "cat:crm",
+  "description": "Photo rapide de la santé HubSpot : volumes, complétude, anomalies.",
+  "instructions": "Tu es un agent d'audit CRM. Via scripts/pocket_hubspot.py (lecture) : 1) compte les contacts par lifecyclestage (count). 2) Estime la complétude sur 2-3 propriétés clés (email, téléphone, industry_emalist sur companies) via search/count. 3) Repère 2-3 anomalies ou gaps ICP. Rends un rapport court et chiffré, prêt à lire. Lecture seule — aucune écriture.",
+  "created": 0
+}

--- a/pocket-modes/veille-concurrent.json
+++ b/pocket-modes/veille-concurrent.json
@@ -1,0 +1,8 @@
+{
+  "name": "Veille concurrent",
+  "slug": "veille-concurrent",
+  "category": "cat:web",
+  "description": "Recherche web sur un concurrent ou un sujet, synthèse sourcée.",
+  "instructions": "Tu es un agent de veille. À partir du sujet/concurrent donné dans la demande : fais des recherches web (curl/firecrawl), puis synthétise en 5 points maximum, factuels et SOURCÉS (mets le lien à chaque point). Termine par 1 'signal' actionnable pour EMAsphere (growth/CRM B2B). Lecture seule.",
+  "created": 0
+}


### PR DESCRIPTION
Créer/déployer/lancer des agents personnalisés depuis le téléphone + activité live, durées d'étape, lien logs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce agent modes to Claude Pocket and enhance live run monitoring for GitHub-based executions.

New Features:
- Allow creating, editing, and deleting reusable agent modes stored as JSON files in the repository and selectable when launching a task.
- Add a dedicated UI section for managing agent modes and exposing them as quick-select chips in the task composer.
- Pass the selected agent mode into created issues so workflows can load and follow mode-specific instructions during runs.

Enhancements:
- Display per-step durations and a link to full GitHub Actions logs in the task detail monitor view.
- Surface the latest live progress message from the workflow as an in-app activity indicator while runs are in progress.
- Update Claude Pocket to version v9 and bump the service worker cache version accordingly.

Build:
- Adjust the Pocket GitHub Actions workflow to read and obey pocket mode instructions from repository JSON files when a non-auto mode is specified.