### PR TITLE
feat(pocket): v10 — scheduled agentic modes

### DIFF
--- a/.github/workflows/pocket-schedule.yml
+++ b/.github/workflows/pocket-schedule.yml
@@ -1,0 +1,109 @@
+name: Pocket Scheduler
+
+# Déclenche les modes programmés (pocket-schedules/*.json). Crée la tâche ET
+# exécute l'agent dans le même run (pas de second workflow à déclencher).
+on:
+  schedule:
+    - cron: '0 * * * *'   # toutes les heures (coût maîtrisé ; précision ~1h, suffisant)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Decide & create scheduled task
+        id: fire
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/pocket_scheduler.py
+
+      - name: Commit last_fired
+        run: |
+          if [ -n "$(git status --porcelain pocket-schedules/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add pocket-schedules/
+            git commit -m "pocket: scheduler last_fired" || true
+            git push || true
+          fi
+
+      - name: Install MCP servers
+        if: steps.fire.outputs.fired == 'true'
+        run: npm install -g @modelcontextprotocol/server-github @hubspot/mcp-server
+
+      - name: Write MCP config
+        if: steps.fire.outputs.fired == 'true'
+        env:
+          GH_TOKEN_MCP: ${{ secrets.GITHUB_TOKEN }}
+          HUBSPOT_TOKEN_MCP: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
+          LEMLIST_KEY_MCP: ${{ secrets.LEMLIST_API_KEY }}
+        run: |
+          python3 -c "
+          import json, os
+          cfg = {'mcpServers': {'github': {'command': 'npx', 'args': ['-y', '@modelcontextprotocol/server-github'], 'env': {'GITHUB_PERSONAL_ACCESS_TOKEN': os.environ['GH_TOKEN_MCP']}}}}
+          if os.environ.get('HUBSPOT_TOKEN_MCP'):
+              cfg['mcpServers']['hubspot'] = {'command': 'npx', 'args': ['-y', '@hubspot/mcp-server'], 'env': {'PRIVATE_APP_ACCESS_TOKEN': os.environ['HUBSPOT_TOKEN_MCP']}}
+          if os.environ.get('LEMLIST_KEY_MCP'):
+              cfg['mcpServers']['lemlist'] = {'type': 'http', 'url': 'https://app.lemlist.com/mcp', 'headers': {'X-API-Key': os.environ['LEMLIST_KEY_MCP']}}
+          json.dump(cfg, open('/tmp/mcp-config.json', 'w'))
+          "
+
+      - name: Build claude_args
+        if: steps.fire.outputs.fired == 'true'
+        run: |
+          READ="mcp__hubspot__hubspot-search-objects,mcp__hubspot__hubspot-list-objects,mcp__hubspot__hubspot-batch-read-objects,mcp__hubspot__hubspot-list-properties,mcp__hubspot__hubspot-get-property,mcp__hubspot__hubspot-get-schemas,mcp__hubspot__hubspot-list-associations,mcp__hubspot__hubspot-list-workflows,mcp__hubspot__hubspot-get-workflow,mcp__hubspot__hubspot-get-engagement,mcp__lemlist__get_campaigns,mcp__lemlist__get_campaign_details,mcp__lemlist__get_campaigns_stats,mcp__lemlist__search_contacts"
+          echo "CLAUDE_ARGS=--model claude-opus-4-8 --max-turns 15 --allowedTools Bash,Read,mcp__github__add_issue_comment,$READ --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
+
+      - name: Run Claude Pocket (scheduled)
+        if: steps.fire.outputs.fired == 'true'
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        env:
+          HUBSPOT_PRIVATE_APP_TOKEN: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
+          LEMLIST_API_KEY: ${{ secrets.LEMLIST_API_KEY }}
+          FULLENRICH_API_KEY: ${{ secrets.FULLENRICH_API_KEY }}
+          PHANTOMBUSTER_API_KEY: ${{ secrets.PHANTOMBUSTER_API_KEY }}
+          VAULT_DEPLOY_KEY: ${{ secrets.VAULT_DEPLOY_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Tu es Claude Pocket (tâche PROGRAMMÉE). Lecture seule (pas d'écriture, pas d'approbation possible en automatique).
+            1. `cat /tmp/agent_task.json` (issue_number, description avec "### Mode") et `cat docs/runner-guardrails.md`.
+            2. La demande indique un "### Mode" : `cat pocket-modes/<slug>.json` et **suis STRICTEMENT son champ `instructions`**.
+               Pour HubSpot : `python3 scripts/pocket_hubspot.py ...`. Vault : `python3 scripts/pocket_vault.py search/read`.
+            3. Poste un bref commentaire de progression puis le RÉSULTAT FINAL sur l'issue :
+               `gh issue comment ${{ steps.fire.outputs.issue }} --body "..."`
+            4. Classe : `gh issue edit ${{ steps.fire.outputs.issue }} --add-label "<cat du mode>"`.
+          claude_args: ${{ env.CLAUDE_ARGS }}
+          settings: |
+            {
+              "env": {
+                "GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+                "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+                "GITHUB_REPOSITORY": "${{ github.repository }}",
+                "HUBSPOT_PRIVATE_APP_TOKEN": "${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}",
+                "LEMLIST_API_KEY": "${{ secrets.LEMLIST_API_KEY }}"
+              }
+            }
+
+      - name: Notify (push)
+        if: steps.fire.outputs.fired == 'true'
+        env:
+          VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
+          VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
+        run: |
+          pip install --quiet pywebpush || true
+          python3 scripts/pocket_push.py --title "Claude Pocket ⏰" --body "Tâche programmée #${{ steps.fire.outputs.issue }} terminée." --url "./" || true

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,7 +2,7 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v9';
+const APP_VERSION = 'v10';
 const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
 function estTokens(text) { return Math.round((text || '').length / 4); }
 function slugify(s) { return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40); }
@@ -169,7 +169,7 @@ function renderModes() {
     ul.appendChild(li);
   }
 }
-function openModeEditor(mode) {
+async function openModeEditor(mode) {
   editingMode = mode || null;
   $('mode-editor').classList.remove('hidden');
   $('mode-name').value = mode ? mode.name : '';
@@ -178,7 +178,32 @@ function openModeEditor(mode) {
   $('mode-instr').value = mode ? mode.instructions : '';
   $('mode-delete').classList.toggle('hidden', !mode);
   $('mode-msg').textContent = '';
+  // Programmation : reset puis charge si existante
+  $('mode-freq').value = 'none'; $('sched-extra').classList.add('hidden'); $('weekday-wrap').classList.add('hidden');
+  $('mode-time').value = '08:00'; $('mode-sched-demande').value = '';
+  if (mode) {
+    try {
+      const c = await gh('/contents/pocket-schedules/' + mode.slug + '.json');
+      const sc = JSON.parse(decodeB64(c.content));
+      $('mode-freq').value = sc.freq; $('sched-extra').classList.remove('hidden');
+      $('mode-time').value = String(sc.hour).padStart(2, '0') + ':' + String(sc.minute || 0).padStart(2, '0');
+      $('mode-weekday').value = sc.weekday || 0; $('mode-sched-demande').value = sc.demande || '';
+      $('weekday-wrap').classList.toggle('hidden', sc.freq !== 'weekly');
+    } catch {}
+  }
   $('mode-editor').scrollIntoView({ behavior: 'smooth' });
+}
+async function saveSchedule(slug, name, cat) {
+  const path = 'pocket-schedules/' + slug + '.json';
+  const freq = $('mode-freq').value;
+  if (freq === 'none') {
+    try { const c = await gh('/contents/' + path); await gh('/contents/' + path, { method: 'DELETE', body: JSON.stringify({ message: 'pocket: unschedule ' + slug, sha: c.sha }) }); } catch {}
+    return;
+  }
+  const [hh, mm] = ($('mode-time').value || '08:00').split(':');
+  const obj = { id: slug, mode: slug, name, category: cat, freq, hour: parseInt(hh, 10), minute: parseInt(mm, 10), weekday: parseInt($('mode-weekday').value, 10), demande: $('mode-sched-demande').value.trim() || ('Lance le mode ' + name + '.'), enabled: true, tz: 'Europe/Brussels', last_fired: '' };
+  let sha; try { sha = (await gh('/contents/' + path)).sha; } catch {}
+  await gh('/contents/' + path, { method: 'PUT', body: JSON.stringify({ message: 'pocket: schedule ' + slug, content: b64(JSON.stringify(obj, null, 2)), sha }) });
 }
 async function saveMode() {
   const name = $('mode-name').value.trim(), instr = $('mode-instr').value.trim(), m = $('mode-msg');
@@ -190,7 +215,8 @@ async function saveMode() {
     let sha = editingMode ? editingMode._sha : undefined;
     if (!sha) { try { sha = (await gh('/contents/pocket-modes/' + slug + '.json')).sha; } catch {} }
     await gh('/contents/pocket-modes/' + slug + '.json', { method: 'PUT', body: JSON.stringify({ message: 'pocket: mode ' + slug, content: b64(JSON.stringify(obj, null, 2)), sha }) });
-    m.className = 'msg ok'; m.textContent = '✅ Mode déployé — utilisable au lancement d\'une tâche.';
+    await saveSchedule(slug, name, obj.category);
+    m.className = 'msg ok'; m.textContent = '✅ Mode déployé' + ($('mode-freq').value !== 'none' ? ' + programmé.' : ' — utilisable au lancement d\'une tâche.');
     $('mode-editor').classList.add('hidden');
     await loadModes(); renderModes();
   } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
@@ -199,6 +225,7 @@ async function deleteMode() {
   if (!editingMode) return; const m = $('mode-msg'); m.className = 'msg'; m.textContent = 'Suppression…';
   try {
     await gh('/contents/pocket-modes/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: delete mode ' + editingMode.slug, sha: editingMode._sha }) });
+    try { const c = await gh('/contents/pocket-schedules/' + editingMode.slug + '.json'); await gh('/contents/pocket-schedules/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: unschedule ' + editingMode.slug, sha: c.sha }) }); } catch {}
     if (selectedMode === editingMode.slug) selectedMode = 'auto';
     $('mode-editor').classList.add('hidden'); await loadModes(); renderModes();
   } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
@@ -394,6 +421,7 @@ function init() {
   $('mode-new').onclick = () => openModeEditor(null);
   $('mode-save').onclick = saveMode;
   $('mode-delete').onclick = deleteMode;
+  $('mode-freq').onchange = (e) => { $('sched-extra').classList.toggle('hidden', e.target.value === 'none'); $('weekday-wrap').classList.toggle('hidden', e.target.value !== 'weekly'); };
   $('system-back').onclick = () => history.back();
   $('back').onclick = () => history.back();
   $('save-settings').onclick = async () => {

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -37,7 +37,7 @@
   </svg>
 
   <header>
-    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v8</span></button>
+    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v10</span></button>
     <div class="hbtns">
       <button class="icon-btn" id="nav-modes" title="Modes agentiques"><svg class="ic"><use href="#i-robot"/></svg></button>
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
@@ -103,6 +103,26 @@
       <label>Instructions (le « cerveau » de l'agent)
         <textarea id="mode-instr" rows="6" placeholder="Tu es un agent qui… Décris précisément sa mission, ses étapes, ses limites."></textarea>
       </label>
+      <label><svg class="ic"><use href="#i-clock"/></svg> Déclenchement programmé
+        <select id="mode-freq">
+          <option value="none">Aucun (lancement manuel)</option>
+          <option value="daily">Tous les jours</option>
+          <option value="weekly">Chaque semaine</option>
+        </select>
+      </label>
+      <div id="sched-extra" class="hidden">
+        <label>Heure <input id="mode-time" type="time" value="08:00" /></label>
+        <label id="weekday-wrap" class="hidden">Jour
+          <select id="mode-weekday">
+            <option value="0">Lundi</option><option value="1">Mardi</option><option value="2">Mercredi</option>
+            <option value="3">Jeudi</option><option value="4">Vendredi</option><option value="5">Samedi</option><option value="6">Dimanche</option>
+          </select>
+        </label>
+        <label>Demande à lancer automatiquement
+          <textarea id="mode-sched-demande" rows="2" placeholder="Ex : Lance l'audit CRM hebdomadaire."></textarea>
+        </label>
+        <p class="hint" style="margin-top:0">Lecture seule (les tâches programmées ne font pas d'écriture sans toi). Fuseau : Europe/Brussels. Tu recevras une notif à la fin.</p>
+      </div>
       <button id="mode-save" class="primary"><svg class="ic"><use href="#i-check"/></svg> Déployer le mode</button>
       <button id="mode-delete" class="ghost hidden">Supprimer ce mode</button>
       <p id="mode-msg" class="msg"></p>

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v9';
+const CACHE = 'pocket-v10';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {

--- a/scripts/pocket_scheduler.py
+++ b/scripts/pocket_scheduler.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3.12
+"""Planificateur Claude Pocket : déclenche les modes programmés.
+
+Lit pocket-schedules/*.json. Pour le 1er planning « dû » dans la fenêtre courante
+(tz Europe/Brussels par défaut), crée une issue Pocket (label pocket) via l'API,
+écrit /tmp/agent_task.json, et signale `fired` au workflow (qui lance l'agent inline).
+Met à jour last_fired (dédup : un déclenchement max par jour et par planning).
+
+Env requis : GITHUB_REPOSITORY, GH_TOKEN. Écrit dans GITHUB_OUTPUT : fired, issue.
+"""
+import os, json, glob, datetime, urllib.request
+from zoneinfo import ZoneInfo
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["GH_TOKEN"]
+OUT = os.environ.get("GITHUB_OUTPUT", "/dev/stdout")
+
+
+def create_issue(title, body):
+    data = json.dumps({"title": title, "body": body, "labels": ["pocket"]}).encode()
+    req = urllib.request.Request(f"https://api.github.com/repos/{REPO}/issues", data=data, method="POST")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("Accept", "application/vnd.github+json")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())["number"]
+
+
+def is_due(s, now):
+    if not s.get("enabled"):
+        return False
+    if s.get("freq") == "weekly" and now.weekday() != int(s.get("weekday", 0)):
+        return False
+    target = now.replace(hour=int(s["hour"]), minute=int(s.get("minute", 0)), second=0, microsecond=0)
+    delta = (now - target).total_seconds()
+    if not (0 <= delta < 70 * 60):  # fenêtre de 70 min (cron horaire + retards GitHub)
+        return False
+    if (s.get("last_fired", "") or "").startswith(now.strftime("%Y-%m-%d")):
+        return False  # déjà déclenché aujourd'hui
+    return True
+
+
+def main():
+    fired = None
+    for f in sorted(glob.glob("pocket-schedules/*.json")):
+        try:
+            s = json.load(open(f))
+        except Exception:
+            continue
+        now = datetime.datetime.now(ZoneInfo(s.get("tz", "Europe/Brussels")))
+        if is_due(s, now):
+            body = f"### Demande\n\n{s['demande']}\n\n### Autoriser l'écriture ?\n\nnon\n\n### Mode\n\n{s['mode']}"
+            num = create_issue(f"[Pocket] ⏰ {s.get('name', s['mode'])}", body)
+            s["last_fired"] = now.isoformat()
+            json.dump(s, open(f, "w"), indent=2, ensure_ascii=False)
+            json.dump({"source": "pocket-schedule", "issue_number": str(num), "description": body,
+                       "approved": False, "is_followup": False, "latest_message": ""},
+                      open("/tmp/agent_task.json", "w"))
+            fired = num
+            break  # un seul déclenchement par tick (les autres suivront au tick suivant)
+
+    with open(OUT, "a") as o:
+        o.write(f"fired={'true' if fired else 'false'}\n")
+        if fired:
+            o.write(f"issue={fired}\n")
+    print("fired:", fired)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Programmer un mode (quotidien/hebdo). Planificateur sans credential supplémentaire (crée la tâche + lance l'agent inline). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add scheduled execution support for Claude Pocket modes and wire it into a new GitHub Actions workflow.

New Features:
- Allow configuring daily or weekly scheduled runs for Pocket agent modes, including time, weekday, and an automatic prompt.
- Introduce a Pocket Scheduler GitHub Actions workflow that scans configured schedules, opens corresponding Pocket issues, and triggers the inline agent run with read-only guardrails.

Enhancements:
- Persist and manage schedule definitions per mode via JSON files in pocket-schedules/, including automatic creation, update, and removal when modes are saved or deleted.
- Update the Pocket web UI to expose scheduling options in the mode editor and show appropriate deployment feedback.
- Bump Pocket app, UI version badge, and service-worker cache version to v10 so clients pick up the new behavior.