### PR TITLE
feat(pocket): v11 — expertise memory + fuller tools + chains

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -74,7 +74,7 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +96,8 @@ jobs:
           GH_TOKEN_MCP: ${{ secrets.GITHUB_TOKEN }}
           HUBSPOT_TOKEN_MCP: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
           LEMLIST_KEY_MCP: ${{ secrets.LEMLIST_API_KEY }}
+          TAVILY_KEY_MCP: ${{ secrets.TAVILY_API_KEY }}
+          FIRECRAWL_KEY_MCP: ${{ secrets.FIRECRAWL_API_KEY }}
         run: |
           python3 -c "
           import json, os
@@ -106,6 +108,10 @@ jobs:
               cfg['mcpServers']['hubspot'] = {'command': 'npx', 'args': ['-y', '@hubspot/mcp-server'], 'env': {'PRIVATE_APP_ACCESS_TOKEN': os.environ['HUBSPOT_TOKEN_MCP']}}
           if os.environ.get('LEMLIST_KEY_MCP'):
               cfg['mcpServers']['lemlist'] = {'type': 'http', 'url': 'https://app.lemlist.com/mcp', 'headers': {'X-API-Key': os.environ['LEMLIST_KEY_MCP']}}
+          if os.environ.get('TAVILY_KEY_MCP'):
+              cfg['mcpServers']['tavily'] = {'command': 'npx', 'args': ['-y', 'tavily-mcp@latest'], 'env': {'TAVILY_API_KEY': os.environ['TAVILY_KEY_MCP']}}
+          if os.environ.get('FIRECRAWL_KEY_MCP'):
+              cfg['mcpServers']['firecrawl'] = {'command': 'npx', 'args': ['-y', 'firecrawl-mcp'], 'env': {'FIRECRAWL_API_KEY': os.environ['FIRECRAWL_KEY_MCP']}}
           json.dump(cfg, open('/tmp/mcp-config.json', 'w'))
           "
 
@@ -113,7 +119,7 @@ jobs:
         env:
           APPROVED: ${{ needs.gate.outputs.approved }}
         run: |
-          READ="mcp__hubspot__hubspot-search-objects,mcp__hubspot__hubspot-list-objects,mcp__hubspot__hubspot-batch-read-objects,mcp__hubspot__hubspot-list-properties,mcp__hubspot__hubspot-get-property,mcp__hubspot__hubspot-get-schemas,mcp__hubspot__hubspot-list-associations,mcp__hubspot__hubspot-list-workflows,mcp__hubspot__hubspot-get-workflow,mcp__hubspot__hubspot-get-engagement,mcp__lemlist__get_campaigns,mcp__lemlist__get_campaign_details,mcp__lemlist__get_campaigns_stats,mcp__lemlist__search_contacts,mcp__lemlist__get_inbox_conversations"
+          READ="mcp__hubspot__hubspot-search-objects,mcp__hubspot__hubspot-list-objects,mcp__hubspot__hubspot-batch-read-objects,mcp__hubspot__hubspot-list-properties,mcp__hubspot__hubspot-get-property,mcp__hubspot__hubspot-get-schemas,mcp__hubspot__hubspot-list-associations,mcp__hubspot__hubspot-list-workflows,mcp__hubspot__hubspot-get-workflow,mcp__hubspot__hubspot-get-engagement,mcp__lemlist__get_campaigns,mcp__lemlist__get_campaign_details,mcp__lemlist__get_campaigns_stats,mcp__lemlist__get_campaigns_reports,mcp__lemlist__search_contacts,mcp__lemlist__search_companies,mcp__lemlist__get_team_overview,mcp__lemlist__get_inbox_conversations,mcp__tavily__tavily_search,mcp__tavily__tavily_extract,mcp__firecrawl__firecrawl_scrape,mcp__firecrawl__firecrawl_search"
           TOOLS="Bash,Read,mcp__github__add_issue_comment,$READ"
           # Outils d'ÉCRITURE seulement si le label `approved` est présent (gate au niveau outil).
           if [[ "$APPROVED" == "true" ]]; then
@@ -131,6 +137,9 @@ jobs:
           FULLENRICH_API_KEY: ${{ secrets.FULLENRICH_API_KEY }}
           PHANTOMBUSTER_API_KEY: ${{ secrets.PHANTOMBUSTER_API_KEY }}
           VAULT_DEPLOY_KEY: ${{ secrets.VAULT_DEPLOY_KEY }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -158,10 +167,16 @@ jobs:
             - **FullEnrich (enrichissement)** — `python3 scripts/pocket_fullenrich.py status|enrich-one|submit` (dry-run sauf --confirm).
             - **PhantomBuster (scraping)** — `python3 scripts/pocket_phantombuster.py agents|agent|containers|output|result` (lecture) ; `launch ... --confirm` (action).
             - **Lemlist (outreach)** — outils MCP `mcp__lemlist__*` en lecture (campagnes, stats, contacts).
-            - **Web** — recherche/scrape via Bash (`curl`) si la demande est une question générale ou a besoin d'info externe.
-            - **Vault (connaissances EMAsphere)** — `python3 scripts/pocket_vault.py search "<requête>"` puis `read "<chemin.md>"` (et `list`) : accès LECTURE aux 2600+ notes du vault Obsidian privé (CRM, growth, playbooks, dev, ICP…). Utilise-le pour toute question « d'après mes notes / mon vault / ce que je sais sur X ».
+            - **Web** — privilégie les MCP : `mcp__tavily__tavily_search` (recherche récente, sourcée), `mcp__tavily__tavily_extract`, `mcp__firecrawl__firecrawl_scrape` / `firecrawl_search` (scrape de pages). `curl` en dernier recours.
+            - **Vault (connaissances EMAsphere)** — `python3 scripts/pocket_vault.py search "<requête>"` puis `read "<chemin.md>"` (et `list`) : accès LECTURE aux 2600+ notes du vault Obsidian privé.
             - **GitHub / repo** — Bash, Read pour le code et le contexte du repo.
-            Si une app pertinente manque de secret, dis-le proprement et propose une alternative — ne plante pas.
+            Exploite à FOND l'outil le plus adapté (ne te limite pas à un seul). Si un secret manque, dis-le proprement et propose une alternative — ne plante pas.
+
+            === MÉMOIRE D'EXPERTISE (tu t'améliores avec le temps) ===
+            - Au DÉMARRAGE, après avoir choisi le domaine, lis ton expertise accumulée : `cat pocket-knowledge/<domaine>.md` (crm/web/vault/enrich/outreach/code/other) si le fichier existe — utilise-la pour mieux répondre.
+            - À la FIN, si tu as appris quelque chose de DURABLE et réutilisable (une correction, un fait stable, une préférence de Gaspard, un pattern), enregistre-le :
+              `python3 scripts/pocket_learn.py <domaine> "<apprentissage concis>"`
+              (n'enregistre que si c'est vraiment réutilisable, jamais de doublon, reste bref).
 
             === MÉTHODE ===
             1. Comprends l'intention.
@@ -172,6 +187,8 @@ jobs:
             3. **Lecture par défaut.** Écriture/action coûteuse (HubSpot write, FullEnrich --confirm, PhantomBuster launch, Lemlist add/send) UNIQUEMENT si `approved` = true ET demandée ET dans les garde-fous. Sinon, poste un PREVIEW de ce que tu ferais et demande le label `approved`.
             4. Poste le RÉSULTAT FINAL en commentaire (clair, prêt à copier, même langue que la demande) :
                `gh issue comment ${{ github.event.issue.number }} --body "..."`
+            5. **Chaîne d'automatisation** : si le mode JSON contient un champ `chain_to` (slug d'un autre mode), enchaîne DANS LA FOULÉE — `cat pocket-modes/<chain_to>.json`, exécute aussi ses `instructions`, et poste son résultat (en précisant « ⛓ Étape suivante : <nom> »). Tu peux ainsi enchaîner plusieurs agents en une seule exécution.
+            6. **Mémoire** : applique la section MÉMOIRE D'EXPERTISE (enregistre un apprentissage durable via `python3 scripts/pocket_learn.py <domaine> "..."` si pertinent).
           claude_args: ${{ env.CLAUDE_ARGS }}
           settings: |
             {

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,7 +2,7 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v10';
+const APP_VERSION = 'v11';
 const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
 function estTokens(text) { return Math.round((text || '').length / 4); }
 function slugify(s) { return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40); }
@@ -191,6 +191,10 @@ async function openModeEditor(mode) {
       $('weekday-wrap').classList.toggle('hidden', sc.freq !== 'weekly');
     } catch {}
   }
+  // Chaînage : liste des autres modes
+  const chainSel = $('mode-chain'); chainSel.innerHTML = '<option value="">Aucun</option>';
+  for (const m of allModes) if (!mode || m.slug !== mode.slug) chainSel.appendChild(new Option(m.name, m.slug));
+  chainSel.value = (mode && mode.chain_to) ? mode.chain_to : '';
   $('mode-editor').scrollIntoView({ behavior: 'smooth' });
 }
 async function saveSchedule(slug, name, cat) {
@@ -210,6 +214,7 @@ async function saveMode() {
   if (!name || !instr) { m.className = 'msg err'; m.textContent = 'Nom et instructions requis.'; return; }
   const slug = editingMode ? editingMode.slug : slugify(name);
   const obj = { name, slug, category: $('mode-cat').value, description: $('mode-desc').value.trim(), instructions: instr, created: editingMode ? editingMode.created : Date.now() };
+  if ($('mode-chain').value) obj.chain_to = $('mode-chain').value;
   m.className = 'msg'; m.textContent = 'Déploiement…';
   try {
     let sha = editingMode ? editingMode._sha : undefined;
@@ -228,6 +233,23 @@ async function deleteMode() {
     try { const c = await gh('/contents/pocket-schedules/' + editingMode.slug + '.json'); await gh('/contents/pocket-schedules/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: unschedule ' + editingMode.slug, sha: c.sha }) }); } catch {}
     if (selectedMode === editingMode.slug) selectedMode = 'auto';
     $('mode-editor').classList.add('hidden'); await loadModes(); renderModes();
+  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
+}
+
+// ── Connaissances (expertise) ────────────────────────────────────────────────
+let knowSha = {};
+async function loadKnowledge() {
+  const domain = $('know-domain').value; $('know-msg').textContent = ''; $('know-text').value = 'Chargement…';
+  try { const c = await gh('/contents/pocket-knowledge/' + domain + '.md'); $('know-text').value = decodeB64(c.content); knowSha[domain] = c.sha; }
+  catch { $('know-text').value = ''; knowSha[domain] = null; }
+}
+async function saveKnowledge() {
+  const domain = $('know-domain').value, m = $('know-msg'); m.className = 'msg'; m.textContent = 'Enregistrement…';
+  try {
+    const body = { message: 'knowledge: ' + domain + ' (édition manuelle)', content: b64($('know-text').value) };
+    if (knowSha[domain]) body.sha = knowSha[domain];
+    const r = await gh('/contents/pocket-knowledge/' + domain + '.md', { method: 'PUT', body: JSON.stringify(body) });
+    knowSha[domain] = r.content.sha; m.className = 'msg ok'; m.textContent = '✅ Enregistré.';
   } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
 }
 
@@ -372,11 +394,13 @@ function applyView(view) {
   $('detail').classList.toggle('hidden', !isDetail);
   $('system').classList.toggle('hidden', view !== 'system');
   $('modes').classList.toggle('hidden', view !== 'modes');
-  const isMain = !isDetail && view !== 'system' && view !== 'modes';
+  $('knowledge').classList.toggle('hidden', view !== 'knowledge');
+  const isMain = !isDetail && !['system', 'modes', 'knowledge'].includes(view);
   for (const id of ['composer', 'history']) $(id).classList.toggle('hidden', !isMain);
   if (!isDetail) stopPoll();
   if (view === 'system') renderSystem();
   else if (view === 'modes') { renderModes(); $('mode-editor').classList.add('hidden'); }
+  else if (view === 'knowledge') loadKnowledge();
   else if (isDetail) loadDetail(parseInt(view.split(':')[1], 10));
   else { detailNum = null; loadHistory(); }
   window.scrollTo(0, 0);
@@ -422,6 +446,10 @@ function init() {
   $('mode-save').onclick = saveMode;
   $('mode-delete').onclick = deleteMode;
   $('mode-freq').onchange = (e) => { $('sched-extra').classList.toggle('hidden', e.target.value === 'none'); $('weekday-wrap').classList.toggle('hidden', e.target.value !== 'weekly'); };
+  $('open-knowledge').onclick = () => navigate('knowledge');
+  $('knowledge-back').onclick = () => history.back();
+  $('know-domain').onchange = loadKnowledge;
+  $('know-save').onclick = saveKnowledge;
   $('system-back').onclick = () => history.back();
   $('back').onclick = () => history.back();
   $('save-settings').onclick = async () => {

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -37,7 +37,7 @@
   </svg>
 
   <header>
-    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v10</span></button>
+    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v11</span></button>
     <div class="hbtns">
       <button class="icon-btn" id="nav-modes" title="Modes agentiques"><svg class="ic"><use href="#i-robot"/></svg></button>
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
@@ -84,6 +84,7 @@
     <button class="link-btn" id="modes-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
     <h2><svg class="ic"><use href="#i-robot"/></svg> Modes agentiques</h2>
     <p class="hint" style="margin-top:0">Crée tes propres agents : un nom, une catégorie et des instructions. Ils deviennent sélectionnables au lancement d'une tâche.</p>
+    <button id="open-knowledge" class="ghost" style="margin-top:8px"><svg class="ic"><use href="#i-brain"/></svg> Connaissances accumulées</button>
     <button id="mode-new" class="primary" style="margin:12px 0"><svg class="ic"><use href="#i-plus"/></svg> Nouveau mode</button>
     <ul id="modes-list"></ul>
     <div id="mode-editor" class="hidden" style="margin-top:14px;border-top:1px solid var(--line);padding-top:14px">
@@ -100,6 +101,9 @@
         </select>
       </label>
       <label>Description <input id="mode-desc" type="text" placeholder="À quoi sert cet agent" /></label>
+      <label><svg class="ic"><use href="#i-robot"/></svg> Enchaîner vers (chaîne d'automatisation)
+        <select id="mode-chain"><option value="">Aucun</option></select>
+      </label>
       <label>Instructions (le « cerveau » de l'agent)
         <textarea id="mode-instr" rows="6" placeholder="Tu es un agent qui… Décris précisément sa mission, ses étapes, ses limites."></textarea>
       </label>
@@ -127,6 +131,23 @@
       <button id="mode-delete" class="ghost hidden">Supprimer ce mode</button>
       <p id="mode-msg" class="msg"></p>
     </div>
+  </section>
+
+  <!-- ── Connaissances (expertise accumulée) ── -->
+  <section id="knowledge" class="card hidden">
+    <button class="link-btn" id="knowledge-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
+    <h2><svg class="ic"><use href="#i-brain"/></svg> Connaissances accumulées</h2>
+    <p class="hint" style="margin-top:0">Ce que Pocket a appris par domaine. Tu peux corriger ou élaguer.</p>
+    <label>Domaine
+      <select id="know-domain">
+        <option value="crm">CRM</option><option value="web">Web</option><option value="vault">Vault</option>
+        <option value="enrich">Enrichissement</option><option value="outreach">Outreach</option>
+        <option value="code">Code</option><option value="other">Autre</option>
+      </select>
+    </label>
+    <textarea id="know-text" rows="12" placeholder="(vide — Pocket apprendra au fil des tâches)"></textarea>
+    <button id="know-save" class="primary" style="margin-top:10px"><svg class="ic"><use href="#i-check"/></svg> Enregistrer</button>
+    <p id="know-msg" class="msg"></p>
   </section>
 
   <!-- ── Composer ── -->

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v10';
+const CACHE = 'pocket-v11';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {

--- a/pocket-knowledge/README.md
+++ b/pocket-knowledge/README.md
@@ -1,0 +1,8 @@
+# Mémoire d'expertise — Claude Pocket
+
+Un fichier par domaine (`crm.md`, `web.md`, `vault.md`, `enrich.md`, `outreach.md`, `code.md`, `other.md`).
+L'agent **lit** le fichier du domaine concerné avant d'agir, et y **ajoute** ses apprentissages durables
+à la fin d'une tâche (corrections, faits stables, préférences de Gaspard, patterns réutilisables).
+
+Règles : entrées **concises**, datées, **dédupliquées**, seulement ce qui est **réutilisable**.
+Gaspard peut éditer/élaguer ces fichiers depuis l'app (vue Connaissances).

--- a/pocket-knowledge/crm.md
+++ b/pocket-knowledge/crm.md
@@ -1,0 +1,8 @@
+# Expertise CRM (HubSpot) — appris par Pocket
+
+- Volumes typiques (juin 2026) : ~278k contacts, ~155k companies. Lead ≈ 61 %, MQL ≈ 28 %.
+- `lifecyclestage` = propriété clé pour segmenter. Industry sur **companies** = `industry_emalist`.
+- Le token Pocket n'a pas le scope deals (403) — auditer deals via UI ou élargir le token.
+- ICP : CA 10–500 M€, >50 employés, CFO/DAF, BE+FR, multi-entités.
+
+<!-- L'agent ajoute ici ses apprentissages durables (datés, concis, dédupliqués). -->

--- a/scripts/pocket_learn.py
+++ b/scripts/pocket_learn.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3.12
+"""Enregistre un apprentissage durable dans la mémoire d'expertise de Pocket.
+
+Ajoute une puce datée à pocket-knowledge/<domaine>.md via l'API Contents
+(robuste, pas de git push). Dédup simple. Env : GH_TOKEN, GITHUB_REPOSITORY.
+
+Usage : pocket_learn.py <domaine> "<apprentissage concis>"
+  domaines : crm | web | vault | enrich | outreach | code | other
+"""
+import os, sys, json, base64, datetime, urllib.request, urllib.error
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "")
+TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+VALID = {"crm", "web", "vault", "enrich", "outreach", "code", "other"}
+
+
+def api(method, path, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(f"https://api.github.com/repos/{REPO}{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("Accept", "application/vnd.github+json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+
+
+def main():
+    if len(sys.argv) < 3 or not TOKEN or not REPO:
+        print("usage: pocket_learn.py <domaine> \"<apprentissage>\" (et env GH_TOKEN/GITHUB_REPOSITORY)")
+        return
+    domain = sys.argv[1].strip().lower()
+    if domain not in VALID:
+        domain = "other"
+    learning = " ".join(sys.argv[2:]).strip().replace("\n", " ")
+    if len(learning) < 5:
+        print("trop court — ignoré")
+        return
+    path = f"pocket-knowledge/{domain}.md"
+    st, cur = api("GET", f"/contents/{path}")
+    if st == 200:
+        content = base64.b64decode(cur["content"]).decode("utf-8", "ignore")
+        sha = cur.get("sha")
+    else:
+        content = f"# Expertise {domain} — appris par Pocket\n"
+        sha = None
+    if learning.lower() in content.lower():
+        print("déjà connu — ignoré")
+        return
+    bullet = f"- ({datetime.date.today().isoformat()}) {learning}\n"
+    new = content.rstrip("\n") + "\n" + bullet
+    body = {"message": f"knowledge: {domain}", "content": base64.b64encode(new.encode()).decode()}
+    if sha:
+        body["sha"] = sha
+    st2, _ = api("PUT", f"/contents/{path}", body)
+    print("enregistré" if st2 in (200, 201) else f"échec PUT {st2}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Mémoire d'expertise (apprend avec le temps), Tavily/Firecrawl, chaînage de modes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add persistent expertise memory, extend web tooling, and support automated chaining between agent modes in Claude Pocket v11.

New Features:
- Introduce an expertise memory system backed by per-domain markdown files that Pocket reads and updates over time.
- Expose a new Knowledge view in the Pocket UI to inspect, edit, and save domain-specific expertise.
- Allow agent modes to define a follow-up mode for automation chains via a new chaining selector and `chain_to` field.
- Add Tavily and Firecrawl MCP servers and tools for web search and scraping in Pocket workflows.

Enhancements:
- Document and enforce an expertise-learning workflow for Pocket using the new memory system and automation chains.
- Update app, UI, and service worker versions to v11 for cache and branding alignment.

Build:
- Relax workflow permissions to allow writing repository contents for expertise updates and mode chaining metadata.

CI:
- Extend the Pocket GitHub Actions workflow to configure Tavily and Firecrawl MCP servers and expose their tools to the agent.
- Wire secrets (TAVILY_API_KEY, FIRECRAWL_API_KEY, GH_TOKEN) into the Pocket workflow environment.

Documentation:
- Add documentation for the expertise memory files layout and editing rules in `pocket-knowledge/README.md`.
- Seed initial CRM expertise content in `pocket-knowledge/crm.md` for Pocket to leverage.

Chores:
- Add the `scripts/pocket_learn.py` helper to append de-duplicated, dated learnings to per-domain knowledge files via the GitHub Contents API.