### PR TITLE
fix(pocket): pre-install web MCP servers

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install MCP servers
-        run: npm install -g @modelcontextprotocol/server-github @hubspot/mcp-server
+        run: npm install -g @modelcontextprotocol/server-github @hubspot/mcp-server tavily-mcp firecrawl-mcp
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Pré-installe tavily-mcp/firecrawl-mcp pour un démarrage MCP fiable. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Pocket CI workflow to globally install additional MCP servers required for reliable MCP startup.

Bug Fixes:
- Pre-install tavily-mcp and firecrawl-mcp MCP servers in the Pocket GitHub workflow to ensure they are available at job startup.

CI:
- Extend the Pocket GitHub Actions workflow MCP installation step to include tavily-mcp and firecrawl-mcp packages.