### PR TITLE
feat(pocket): v13 — markdown render + Google Sheets

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -140,6 +140,7 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_SA_JSON: ${{ secrets.GOOGLE_SA_JSON }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -177,6 +178,7 @@ jobs:
             - **FullEnrich — CSV des résultats** : après un batch FINISHED → `python3 scripts/pocket_fullenrich.py results-csv <enrichment_id>` → CSV emails/téléphones + `csv_url`.
             - **HubSpot segment → enrichir → CSV** : `pocket_hubspot.py lists "<mot>"` pour trouver le segment → `list-members <listId>` (ou `export-list <listId>`) → construis un fichier contacts → `pocket_fullenrich.py submit --file <f> --confirm` (si `approved`) → poll `status` → `results-csv`. Renvoie le `csv_url` final à Gaspard (il gère ensuite lui-même).
             - **HubSpot — expertise objets** : objets = `contacts`, `companies`, `deals` (+ autres). `describe <objet>` (comprendre les propriétés), `count/search/read`, `export <objet> <prop> <valeur>` (→ CSV). Industry = `industry_emalist` sur companies.
+            - **Google Sheets** : `python3 scripts/pocket_sheets.py read <sheetId> [--gid N]` / `export <sheetId>` (lecture/CSV) ; `append <sheetId> <onglet> --row "a,b,c" --confirm` / `write <sheetId> <range> --values-file f.json --confirm` (écriture, si `approved` + compte de service `GOOGLE_SA_JSON`). Si le sheet est privé et qu'il n'y a pas de SA, dis-le proprement (à partager avec le compte de service).
             - **OUTPUTS / FICHIERS** : tout CSV produit est écrit dans `pocket-data/outputs/` et la commande te renvoie un `csv_url` (lien raw). **Donne TOUJOURS ce lien dans ton commentaire** (ex : « 📥 CSV : <url> ») — Gaspard le télécharge depuis l'app.
 
             === MÉMOIRE D'EXPERTISE (tu t'améliores avec le temps) ===

--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -2,7 +2,7 @@
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
 const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v12';
+const APP_VERSION = 'v13';
 const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
 function estTokens(text) { return Math.round((text || '').length / 4); }
 function slugify(s) { return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40); }
@@ -330,16 +330,52 @@ function loadDetail(number) {
   };
   load(); pollTimer = setInterval(load, 6000);
 }
-function linkify(safe) {
-  return safe.replace(/(https?:\/\/[^\s<]+)/g, (u) => {
-    const clean = u.replace(/&amp;/g, '&');
-    if (/\.csv(\?|$)/i.test(clean)) return `<a class="dl" href="${clean}" target="_blank" rel="noopener">📥 Télécharger le CSV</a>`;
-    return `<a href="${clean}" target="_blank" rel="noopener">${u.length > 50 ? u.slice(0, 47) + '…' : u}</a>`;
-  });
+// ── Mini-rendu Markdown (sensation Claude Desktop) ───────────────────────────
+function mdLink(u, text) {
+  const clean = u.replace(/&amp;/g, '&');
+  if (/\.csv(\?|$)/i.test(clean)) return `<a class="dl" href="${clean}" target="_blank" rel="noopener">📥 Télécharger le CSV</a>`;
+  return `<a href="${clean}" target="_blank" rel="noopener">${text || (clean.length > 46 ? clean.slice(0, 43) + '…' : clean)}</a>`;
+}
+function mdInline(s) {
+  s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+  s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  s = s.replace(/(^|[^*\w])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+  s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, (m, t, u) => mdLink(u, t));
+  try { s = s.replace(/(?<!["'>=\/])(https?:\/\/[^\s<]+)/g, (m, u) => mdLink(u, null)); } catch { /* lookbehind non supporté */ }
+  return s;
+}
+function splitRow(l) { return l.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|').map((x) => x.trim()); }
+function renderMarkdown(raw) {
+  try {
+    const lines = escapeHtml(raw).split('\n'); let html = '', i = 0;
+    const blockStart = /^(#{1,6}\s|```|\s*[-*+]\s|\s*\d+\.\s|\s*>|\|)/;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (/^```/.test(line.trim())) { let code = ''; i++; while (i < lines.length && !/^```/.test(lines[i].trim())) { code += lines[i] + '\n'; i++; } i++; html += `<pre><code>${code.replace(/\n$/, '')}</code></pre>`; continue; }
+      if (line.includes('|') && i + 1 < lines.length && lines[i + 1].includes('-') && /^[\s:|\-]+$/.test(lines[i + 1])) {
+        const header = splitRow(line); i += 2; const rows = [];
+        while (i < lines.length && lines[i].includes('|') && lines[i].trim() !== '') { rows.push(splitRow(lines[i])); i++; }
+        html += '<table><thead><tr>' + header.map((h) => `<th>${mdInline(h)}</th>`).join('') + '</tr></thead><tbody>' + rows.map((r) => '<tr>' + r.map((c) => `<td>${mdInline(c)}</td>`).join('') + '</tr>').join('') + '</tbody></table>'; continue;
+      }
+      const h = line.match(/^(#{1,6})\s+(.*)$/); if (h) { const lvl = Math.min(6, h[1].length); html += `<h${lvl} class="md-h">${mdInline(h[2])}</h${lvl}>`; i++; continue; }
+      if (/^\s*([-*_])\1\1+\s*$/.test(line)) { html += '<hr>'; i++; continue; }
+      if (/^\s*>\s?/.test(line)) { let q = ''; while (i < lines.length && /^\s*>\s?/.test(lines[i])) { q += lines[i].replace(/^\s*>\s?/, '') + '\n'; i++; } html += `<blockquote>${mdInline(q.trim()).replace(/\n/g, '<br>')}</blockquote>`; continue; }
+      if (/^\s*[-*+]\s+/.test(line) || /^\s*\d+\.\s+/.test(line)) {
+        const ordered = /^\s*\d+\.\s+/.test(line); const items = [];
+        while (i < lines.length && (/^\s*[-*+]\s+/.test(lines[i]) || /^\s*\d+\.\s+/.test(lines[i]))) { items.push(lines[i].replace(/^\s*(?:[-*+]|\d+\.)\s+/, '')); i++; }
+        html += (ordered ? '<ol>' : '<ul>') + items.map((it) => `<li>${mdInline(it)}</li>`).join('') + (ordered ? '</ol>' : '</ul>'); continue;
+      }
+      if (line.trim() === '') { i++; continue; }
+      let para = line; i++;
+      while (i < lines.length && lines[i].trim() !== '' && !blockStart.test(lines[i]) && !/^\s*([-*_])\1\1+\s*$/.test(lines[i])) { para += '\n' + lines[i]; i++; }
+      html += `<p>${mdInline(para).replace(/\n/g, '<br>')}</p>`;
+    }
+    return html;
+  } catch { return escapeHtml(raw); }
 }
 function bubble(who, text, kind, ts, prog) {
   const div = document.createElement('div'); div.className = 'comment ' + kind + (prog ? ' progress' : '');
-  div.innerHTML = `<div class="who">${escapeHtml(who)}${ts ? ' · ' + timeago(ts) : ''}</div>${linkify(escapeHtml(text))}`; return div;
+  div.innerHTML = `<div class="who">${escapeHtml(who)}${ts ? ' · ' + timeago(ts) : ''}</div><div class="md">${renderMarkdown(text)}</div>`; return div;
 }
 async function chatSend() {
   const ta = $('chat-input'), txt = ta.value.trim(); if (!txt || detailNum == null) return;

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -37,7 +37,7 @@
   </svg>
 
   <header>
-    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v12</span></button>
+    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v13</span></button>
     <div class="hbtns">
       <button class="icon-btn" id="nav-modes" title="Modes agentiques"><svg class="ic"><use href="#i-robot"/></svg></button>
       <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -158,6 +158,22 @@ ul { list-style: none; padding: 0; margin: 0; }
 .comment.user .who { color: var(--accent); }
 .comment a { color: var(--accent); }
 .comment a.dl { display: inline-flex; align-items: center; gap: 6px; margin-top: 8px; padding: 9px 14px; background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #fff; border-radius: 10px; font-weight: 650; text-decoration: none; }
+/* rendu markdown dans les bulles */
+.comment .md { white-space: normal; }
+.comment .md > *:first-child { margin-top: 0; }
+.comment .md > *:last-child { margin-bottom: 0; }
+.comment .md p { margin: 7px 0; }
+.comment .md .md-h { font-size: 15px; font-weight: 750; margin: 11px 0 5px; color: var(--text); text-transform: none; letter-spacing: 0; display: block; }
+.comment .md code { background: var(--bg); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; font-size: 12.5px; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+.comment .md pre { background: var(--bg); border: 1px solid var(--line); border-radius: 10px; padding: 11px; overflow-x: auto; margin: 8px 0; }
+.comment .md pre code { background: none; border: none; padding: 0; font-size: 12px; }
+.comment .md table { border-collapse: collapse; width: 100%; font-size: 12.5px; margin: 8px 0; display: block; overflow-x: auto; }
+.comment .md th, .comment .md td { border: 1px solid var(--line); padding: 6px 9px; text-align: left; white-space: nowrap; }
+.comment .md th { background: var(--bg); font-weight: 700; }
+.comment .md ul, .comment .md ol { margin: 6px 0; padding-left: 20px; }
+.comment .md li { margin: 3px 0; }
+.comment .md blockquote { border-left: 3px solid var(--accent); padding-left: 11px; margin: 8px 0; color: var(--muted); }
+.comment .md hr { border: none; border-top: 1px solid var(--line); margin: 11px 0; }
 .empty { color: var(--muted); font-size: 13px; }
 
 .chatbar { display: flex; gap: 8px; align-items: flex-end; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line); }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v12';
+const CACHE = 'pocket-v13';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {

--- a/scripts/pocket_sheets.py
+++ b/scripts/pocket_sheets.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3.12
+"""Pilotage Google Sheets pour Pocket.
+
+LECTURE / EXPORT : via l'export CSV public (aucune auth) — marche sur les sheets
+publics ou « accessibles avec le lien ».
+ÉCRITURE / APPEND : via un compte de service (secret GOOGLE_SA_JSON, partager le
+sheet avec l'email du SA). Gaté par --confirm.
+
+Usage :
+  pocket_sheets.py read <sheetId> [--gid 0] [--limit 50]
+  pocket_sheets.py export <sheetId> [--gid 0]           -> CSV téléchargeable
+  pocket_sheets.py append <sheetId> <onglet> --row "a,b,c" --confirm
+  pocket_sheets.py write <sheetId> <range> --values-file rows.json --confirm
+"""
+import os, sys, json, csv, io, argparse, urllib.request, urllib.parse, urllib.error
+
+
+def _csv_export(sheet_id, gid):
+    url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid={gid}"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            data = r.read().decode("utf-8", "ignore")
+    except urllib.error.HTTPError as e:
+        return None, f"HTTP {e.code} (sheet privé ? partage-le ou rends-le accessible avec le lien)"
+    if data.lstrip().lower().startswith("<!doctype html") or "<html" in data[:200].lower():
+        return None, "Sheet non public — partage-le 'avec le lien' ou avec le compte de service."
+    return data, None
+
+
+def cmd_read(a):
+    data, err = _csv_export(a.sheetId, a.gid)
+    if err:
+        return {"error": err}
+    rows = list(csv.reader(io.StringIO(data)))
+    return {"sheetId": a.sheetId, "gid": a.gid, "lignes": len(rows), "aperçu": rows[: a.limit]}
+
+
+def cmd_export(a):
+    import sys as _s, os as _o
+    _s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+    from pocket_io import save_text
+    data, err = _csv_export(a.sheetId, a.gid)
+    if err:
+        return {"error": err}
+    url = save_text(f"sheet-{a.sheetId}-{a.gid}.csv", data)
+    return {"sheetId": a.sheetId, "csv_url": url or "(échec écriture)"}
+
+
+def _sa_token(scope):
+    raw = os.environ.get("GOOGLE_SA_JSON", "").strip()
+    if not raw:
+        return None, "GOOGLE_SA_JSON absent (ajoute le JSON du compte de service en secret)."
+    try:
+        sa = json.loads(raw)
+        import time, base64
+        try:
+            from cryptography.hazmat.primitives import hashes, serialization
+            from cryptography.hazmat.primitives.asymmetric import padding
+        except ImportError:
+            import subprocess
+            subprocess.run([sys.executable, "-m", "pip", "install", "--quiet", "cryptography"], check=False)
+            from cryptography.hazmat.primitives import hashes, serialization
+            from cryptography.hazmat.primitives.asymmetric import padding
+
+        def b64u(b):
+            return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+        now = int(time.time())
+        head = b64u(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+        claim = b64u(json.dumps({"iss": sa["client_email"], "scope": scope,
+                                 "aud": "https://oauth2.googleapis.com/token", "iat": now, "exp": now + 3600}).encode())
+        key = serialization.load_pem_private_key(sa["private_key"].encode(), password=None)
+        sig = b64u(key.sign(f"{head}.{claim}".encode(), padding.PKCS1v15(), hashes.SHA256()))
+        assertion = f"{head}.{claim}.{sig}"
+        body = urllib.parse.urlencode({"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer", "assertion": assertion}).encode()
+        with urllib.request.urlopen(urllib.request.Request("https://oauth2.googleapis.com/token", data=body), timeout=30) as r:
+            return json.loads(r.read())["access_token"], None
+    except Exception as e:
+        return None, f"Auth compte de service échouée : {e}"
+
+
+def _sheets_api(method, path, token, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(f"https://sheets.googleapis.com/v4/spreadsheets/{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode()[:300]}
+
+
+def cmd_append(a):
+    if not a.confirm:
+        return {"dry_run": True, "note": "Écriture réelle — relancer avec --confirm (après approbation)."}
+    token, err = _sa_token("https://www.googleapis.com/auth/spreadsheets")
+    if err:
+        return {"error": err}
+    row = [c.strip() for c in a.row.split(",")]
+    rng = urllib.parse.quote(a.tab)
+    st, body = _sheets_api("POST", f"{a.sheetId}/values/{rng}:append?valueInputOption=USER_ENTERED", token, {"values": [row]})
+    return body if st == 200 else {"error": body}
+
+
+def cmd_write(a):
+    if not a.confirm:
+        return {"dry_run": True, "note": "Écriture réelle — relancer avec --confirm (après approbation)."}
+    token, err = _sa_token("https://www.googleapis.com/auth/spreadsheets")
+    if err:
+        return {"error": err}
+    values = json.load(open(a.values_file))
+    rng = urllib.parse.quote(a.range)
+    st, body = _sheets_api("PUT", f"{a.sheetId}/values/{rng}?valueInputOption=USER_ENTERED", token, {"values": values})
+    return body if st == 200 else {"error": body}
+
+
+def main():
+    p = argparse.ArgumentParser(prog="pocket_sheets")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    r = sub.add_parser("read"); r.add_argument("sheetId"); r.add_argument("--gid", default="0"); r.add_argument("--limit", type=int, default=50); r.set_defaults(fn=cmd_read)
+    e = sub.add_parser("export"); e.add_argument("sheetId"); e.add_argument("--gid", default="0"); e.set_defaults(fn=cmd_export)
+    ap = sub.add_parser("append"); ap.add_argument("sheetId"); ap.add_argument("tab"); ap.add_argument("--row", required=True); ap.add_argument("--confirm", action="store_true"); ap.set_defaults(fn=cmd_append)
+    wr = sub.add_parser("write"); wr.add_argument("sheetId"); wr.add_argument("range"); wr.add_argument("--values-file", dest="values_file", required=True); wr.add_argument("--confirm", action="store_true"); wr.set_defaults(fn=cmd_write)
+    a = p.parse_args()
+    print(json.dumps(a.fn(a), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Rendu markdown (sensation Claude Desktop) + pilotage Google Sheets. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add markdown rendering to Pocket chat messages and integrate Google Sheets read/write capabilities into the Pocket tooling and workflow.

New Features:
- Render chat messages using a lightweight markdown parser with support for headings, code blocks, lists, tables, blockquotes, links, and inline formatting.
- Provide Google Sheets integration script to read/export sheets via public CSV and append/write using a service account.
- Document Google Sheets commands and usage in the Pocket workflow instructions.

Enhancements:
- Update Pocket app versioning and service worker cache identifiers to v13 to reflect the new release.

CI:
- Expose GOOGLE_SA_JSON as an environment secret in the Pocket GitHub Actions workflow to enable authenticated Google Sheets access.