### PR TITLE
fix(pocket): notify only phone tasks

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -212,7 +212,7 @@ jobs:
             }
 
       - name: Notify (push)
-        if: always()
+        if: always() && contains(github.event.issue.labels.*.name, 'via:phone')
         env:
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}


### PR DESCRIPTION
Notif push uniquement pour les tâches du téléphone (via:phone). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure Pocket push notifications are sent only for tasks labeled with the 'via:phone' issue label.