### PR TITLE
fix(pocket): surface silent agent failures

### DIFF
--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -129,6 +129,7 @@ jobs:
           echo "CLAUDE_ARGS=--model claude-opus-4-8 --max-turns 15 --allowedTools $TOOLS --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
 
       - name: Run Claude Pocket
+        id: claude
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         env:
@@ -211,6 +212,25 @@ jobs:
               }
             }
 
+      # Détecte un échec silencieux de l'agent (ex : token OAuth expiré →
+      # is_error immédiat, coût 0, aucun commentaire posté). Sans ça,
+      # continue-on-error masque l'échec et une fausse notif « terminée » part.
+      - name: Check Claude result
+        id: result
+        if: always()
+        run: echo "ok=$(python3 scripts/pocket_check_result.py)" >> $GITHUB_OUTPUT
+
+      - name: Fallback comment on failure
+        if: always() && steps.result.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "⚠️ **Claude Pocket n'a pas pu traiter cette tâche.**
+
+          Cause la plus probable : le token d'authentification Claude (\`CLAUDE_CODE_OAUTH_TOKEN\`) est expiré ou invalide (échec immédiat, aucun jeton consommé).
+
+          **Pour réparer :** renouvelle le token (\`claude setup-token\` puis \`gh secret set CLAUDE_CODE_OAUTH_TOKEN -R GaspardCoche/agent-system\`) ou ajoute un \`ANTHROPIC_API_KEY\`, puis relance la tâche (nouveau commentaire sur cette issue)." || true
+
       - name: Notify (push)
         if: always() && contains(github.event.issue.labels.*.name, 'via:phone')
         env:
@@ -218,7 +238,19 @@ jobs:
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
         run: |
           pip install --quiet pywebpush || true
-          python3 scripts/pocket_push.py \
-            --title "Claude Pocket" \
-            --body "Tâche #${{ github.event.issue.number }} terminée — ouvre l'app pour voir la réponse." \
-            --url "./" || true
+          if [ "${{ steps.result.outputs.ok }}" = "true" ]; then
+            TITLE="Claude Pocket"
+            BODY="Tâche #${{ github.event.issue.number }} terminée — ouvre l'app pour voir la réponse."
+          else
+            TITLE="Claude Pocket ⚠️"
+            BODY="Tâche #${{ github.event.issue.number }} en échec (auth/token à renouveler). Ouvre l'app pour les détails."
+          fi
+          python3 scripts/pocket_push.py --title "$TITLE" --body "$BODY" --url "./" || true
+
+      # Fait apparaître le run en ROUGE si l'agent a échoué (honnête pour le
+      # dashboard de l'app), après avoir posté le repli et notifié.
+      - name: Fail run if Claude errored
+        if: always() && steps.result.outputs.ok != 'true'
+        run: |
+          echo "::error::Claude Pocket a échoué (is_error). Voir le commentaire de repli sur l'issue #${{ github.event.issue.number }}."
+          exit 1

--- a/scripts/pocket_check_result.py
+++ b/scripts/pocket_check_result.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3.12
+"""Lit le JSON de sortie de claude-code-action et détermine si le run a réussi.
+
+claude-code-action écrit le flux d'événements dans
+/home/runner/work/_temp/claude-execution-output.json. Le dernier événement
+`type=result` porte `is_error`. On considère le run réussi seulement s'il
+existe un événement result sans is_error.
+
+Sort 'true' (succès) ou 'false' (échec). Ne lève jamais : fichier absent /
+illisible / pas de result = 'false' (fail-safe : on préfère signaler un
+faux échec qu'un faux succès silencieux).
+
+Usage: pocket_check_result.py [chemin]
+"""
+import json
+import sys
+
+DEFAULT = "/home/runner/work/_temp/claude-execution-output.json"
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception:
+        print("false")
+        return
+    events = data if isinstance(data, list) else [data]
+    results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
+    print("true" if (results and not results[-1].get("is_error")) else "false")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problème
Le token OAuth CI (`CLAUDE_CODE_OAUTH_TOKEN`) avait expiré → agent Pocket en échec instantané (`is_error`, coût 0, **aucun commentaire**). `continue-on-error: true` masquait l'échec (job vert) + notif push faussement « terminée ». App perçue comme cassée, sans erreur.

## Correctif
- `scripts/pocket_check_result.py` : lit `claude-execution-output.json` → vrai succès/échec (fail-safe).
- `pocket.yml` : échec → **commentaire de repli** sur l'issue, **notif honnête** (⚠️), **run rouge**.

Token renouvelé par ailleurs (secret MAJ 2026-07-06). Plus jamais d'échec d'auth silencieux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Detect and surface silent failures of the Claude Pocket agent in the CI workflow, ensuring runs are marked as failed and users are informed when the agent errors.

Enhancements:
- Add a Python helper script to inspect claude-code-action output and determine whether a run completed successfully or errored.
- Update the Pocket workflow to post a fallback issue comment when the agent fails, adjust push notification messaging based on success or failure, and mark the workflow run as failed on agent errors.

CI:
- Integrate result checking into the Pocket GitHub Actions job using outputs from the Claude step, while keeping the job resilient via continue-on-error.