### PR TITLE
feat(pocket): Phase 0 — health, status, cost, scheduler robustness

### DIFF
--- a/.github/workflows/pocket-health.yml
+++ b/.github/workflows/pocket-health.yml
@@ -1,0 +1,55 @@
+name: Pocket Health
+
+# Canari : teste l'auth Claude (token OAuth) + la présence des secrets, écrit
+# pocket-data/health.json (lu par le panneau « Santé » de l'app) et pousse une
+# alerte si le token est mort. Empêche une panne d'auth de passer inaperçue.
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # toutes les 6 h
+  workflow_dispatch:          # + bouton « Rafraîchir la santé » depuis l'app
+
+permissions:
+  contents: write
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Canary Claude run (test token)
+        id: canary
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: "Réponds exactement: OK"
+          claude_args: --model claude-opus-4-8 --max-turns 1
+
+      - name: Check token & write health.json
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CANARY_MODEL: claude-opus-4-8
+          VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
+          VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
+          # Présence des secrets d'intégration (booléens, jamais les valeurs).
+          HAS_HUBSPOT: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN != '' && '1' || '0' }}
+          HAS_LEMLIST: ${{ secrets.LEMLIST_API_KEY != '' && '1' || '0' }}
+          HAS_FULLENRICH: ${{ secrets.FULLENRICH_API_KEY != '' && '1' || '0' }}
+          HAS_PHANTOMBUSTER: ${{ secrets.PHANTOMBUSTER_API_KEY != '' && '1' || '0' }}
+          HAS_TAVILY: ${{ secrets.TAVILY_API_KEY != '' && '1' || '0' }}
+          HAS_FIRECRAWL: ${{ secrets.FIRECRAWL_API_KEY != '' && '1' || '0' }}
+          HAS_VAULT: ${{ secrets.VAULT_DEPLOY_KEY != '' && '1' || '0' }}
+          HAS_GOOGLE_SA: ${{ secrets.GOOGLE_SA_JSON != '' && '1' || '0' }}
+        run: |
+          pip install --quiet pywebpush || true
+          OK=$(python3 scripts/pocket_check_result.py)
+          echo "token_ok=$OK"
+          python3 scripts/pocket_health.py --token-ok "$OK"

--- a/.github/workflows/pocket-schedule.yml
+++ b/.github/workflows/pocket-schedule.yml
@@ -66,6 +66,7 @@ jobs:
           echo "CLAUDE_ARGS=--model claude-opus-4-8 --max-turns 15 --allowedTools Bash,Read,mcp__github__add_issue_comment,$READ --mcp-config /tmp/mcp-config.json" >> $GITHUB_ENV
 
       - name: Run Claude Pocket (scheduled)
+        id: claude
         if: steps.fire.outputs.fired == 'true'
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
@@ -99,6 +100,19 @@ jobs:
               }
             }
 
+      # Détecte un échec silencieux de l'agent programmé (token mort, etc.).
+      - name: Check Claude result
+        id: result
+        if: steps.fire.outputs.fired == 'true'
+        run: echo "ok=$(python3 scripts/pocket_check_result.py)" >> $GITHUB_OUTPUT
+
+      - name: Fallback comment on failure
+        if: steps.fire.outputs.fired == 'true' && steps.result.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.fire.outputs.issue }} --body "⚠️ **Tâche programmée non traitée** — échec probable d'authentification Claude (token à renouveler). Le run est marqué en échec." || true
+
       - name: Notify (push)
         if: steps.fire.outputs.fired == 'true'
         env:
@@ -106,4 +120,22 @@ jobs:
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
         run: |
           pip install --quiet pywebpush || true
-          python3 scripts/pocket_push.py --title "Claude Pocket ⏰" --body "Tâche programmée #${{ steps.fire.outputs.issue }} terminée." --url "./" || true
+          if [ "${{ steps.result.outputs.ok }}" = "true" ]; then
+            BODY="Tâche programmée #${{ steps.fire.outputs.issue }} terminée."
+          else
+            BODY="Tâche programmée #${{ steps.fire.outputs.issue }} en échec (auth/token). Ouvre l'app."
+          fi
+          python3 scripts/pocket_push.py --title "Claude Pocket ⏰" --body "$BODY" --url "./" || true
+
+      - name: Record status
+        if: steps.fire.outputs.fired == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/pocket_status.py --issue ${{ steps.fire.outputs.issue }} || true
+
+      - name: Fail run if Claude errored
+        if: steps.fire.outputs.fired == 'true' && steps.result.outputs.ok != 'true'
+        run: |
+          echo "::error::Tâche programmée en échec (is_error)."
+          exit 1

--- a/.github/workflows/pocket.yml
+++ b/.github/workflows/pocket.yml
@@ -247,6 +247,15 @@ jobs:
           fi
           python3 scripts/pocket_push.py --title "$TITLE" --body "$BODY" --url "./" || true
 
+      # Enregistre le run (succès, coût réel, durée, système) dans status.json
+      # → alimente le panneau Santé et le suivi de coût de l'app.
+      - name: Record status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/pocket_status.py --issue ${{ github.event.issue.number }} || true
+
       # Fait apparaître le run en ROUGE si l'agent a échoué (honnête pour le
       # dashboard de l'app), après avoir posté le repli et notifié.
       - name: Fail run if Claude errored

--- a/docs/pocket/ROADMAP.md
+++ b/docs/pocket/ROADMAP.md
@@ -1,0 +1,138 @@
+# Claude Pocket — Roadmap d'amélioration
+
+> Document de planification (2026-07-06). Objectif : cadrer tout ce qui pourrait
+> être ajouté pour rapprocher l'app de sa vision, priorisé pour implémentation
+> ultérieure. Rien ici n'est encore implémenté sauf mention « ✅ fait ».
+
+## 🎯 Vision (north star)
+
+**Piloter tous les systèmes de Gaspard depuis le téléphone, en langage naturel,
+avec confiance.** L'iPhone est la télécommande ; GitHub Actions est le cerveau
+cloud (Mac éteint OK) ; l'agent Claude comprend l'intention, choisit le bon
+système et agit — lecture par défaut, écriture gatée.
+
+Trois axes de progrès : **(1) Confiance** (savoir que ça marche), **(2) Couverture**
+(tous les systèmes, pas juste HubSpot/web), **(3) Fluidité** (l'usage doit être
+plus rapide que d'ouvrir un laptop).
+
+## 📍 État actuel (juillet 2026)
+
+**Systèmes câblés :** HubSpot (CRM), FullEnrich, PhantomBuster, Lemlist (lecture),
+Tavily + Firecrawl (web), Vault Obsidian (lecture), Google Sheets, GitHub.
+**Front :** dashboard, composer (voix + fichiers + modes), historique multi-source,
+chat itératif, modes agentiques CRUD + planifiés, base de connaissances, monitoring.
+**Fiabilité :** ✅ échecs d'agent désormais surfacés (PR #141), token OAuth renouvelé.
+
+**Manques structurels identifiés :** pas de vue « santé des systèmes » ; couverture
+limitée aux systèmes growth (ni Ads, ni Gmail, ni Calendar, ni écriture vault) ;
+pas de suivi de coût réel ; alerte proactive d'expiration de token absente.
+
+---
+
+## 🗂️ Catalogue des améliorations (par thème)
+
+Notation effort : **S** (≤½ j) · **M** (1-2 j) · **L** (>2 j). Impact : ⭐→⭐⭐⭐.
+
+### A. Confiance & fiabilité (fondation)
+
+| # | Amélioration | Impact | Effort | Notes |
+|---|---|---|---|---|
+| A1 | **Panneau « Santé des systèmes »** dans l'app : statut vert/rouge par intégration (token Claude, HubSpot, Lemlist, secrets…), âge du token, dernier run OK par système. Lit un `pocket-data/status.json` écrit à chaque run + un check périodique. | ⭐⭐⭐ | M | Réutilise `pocket-smoke.yml`. C'est la réponse directe à « l'app semblait morte sans le dire ». |
+| A2 | **Alerte proactive d'expiration de token** : cron hebdo qui lance un run trivial ; si `is_error`/coût 0 → notif push « ⚠️ auth à renouveler ». | ⭐⭐⭐ | S | Empêche la panne vécue de se reproduire en silence. S'appuie sur `pocket_check_result.py` (✅ déjà là). |
+| A3 | **Bouton « Relancer » sur une tâche échouée** (1 tap → nouveau commentaire déclencheur). | ⭐⭐ | S | Aujourd'hui il faut re-commenter à la main. |
+| A4 | **Taxonomie d'erreurs** : le commentaire de repli détecte le type (secret manquant / rate limit / erreur outil / auth) et donne le remède ciblé. | ⭐⭐ | M | Étend le fallback de la PR #141. |
+| A5 | **Fiabiliser `pocket-schedule.yml`** (même correctif anti-échec-silencieux que pocket.yml). | ⭐⭐ | S | Les modes programmés échoueraient sinon en silence. |
+
+### B. Couverture des systèmes (la vision « tout piloter »)
+
+| # | Amélioration | Impact | Effort | Notes |
+|---|---|---|---|---|
+| B1 | **Google Ads** — `pocket_ads.py` : lecture (spend, perf campagnes) + actions gatées (pause/budget). « Mets en pause la campagne X ». | ⭐⭐⭐ | M | Auth déjà en Keychain (`google-ads-*`), logique Nexus existante à réutiliser. Fort ROI métier. |
+| B2 | **Gmail** — lire/triager la boîte, **rédiger un draft** de réponse depuis le téléphone. « Réponds à ce mail ». | ⭐⭐⭐ | M | `GMAIL_TOKEN_JSON` déjà en secret (agent Iris). Écriture = draft only, jamais d'envoi auto. |
+| B3 | **Écriture Vault** — capturer une note dans le vault Obsidian depuis le tel (aujourd'hui lecture seule). « Note dans le vault : … ». | ⭐⭐ | M | La deploy key est read-only → besoin d'un PAT écriture sur le repo vault + garde-fous. |
+| B4 | **Google Calendar** — voir l'agenda du jour, créer un événement. | ⭐⭐ | M | Nécessite creds Calendar en CI (OAuth séparé de Gmail). |
+| B5 | **Lemlist écriture** — ajouter un lead à une campagne / pause séquence (gaté `approved`). + ajouter `LEMLIST_API_KEY` (manquant). | ⭐⭐ | S | Débloque le pilier outreach (aujourd'hui muet côté secret). |
+| B6 | **Notion / Slack** — si usage récurrent (audit Charleroi = Notion ; « répondre aux collègues » = Slack, vision initiale). | ⭐⭐ | M | À câbler seulement si besoin réel confirmé. |
+| B7 | **Google Analytics** — lecture trafic/conversions rapide. | ⭐ | M | Nice-to-have, complète le tableau growth. |
+
+### C. Fluidité & UX
+
+| # | Amélioration | Impact | Effort | Notes |
+|---|---|---|---|---|
+| C1 | **Sortie en quasi-temps-réel** dans le détail (streaming des étapes de l'agent au lieu du polling des commentaires). | ⭐⭐ | M | Sensation « Claude en direct ». |
+| C2 | **Bibliothèque de prompts paramétrés** (au-delà des 3 chips) : « enrichir liste ___ », « stats campagne ___ » avec champs à remplir. | ⭐⭐ | M | Accélère les tâches récurrentes. |
+| C3 | **Rendu riche des résultats** : CSV → tableau triable + aperçu ; distributions (lifecyclestage…) → mini bar-chart ; images inline. | ⭐⭐ | M | Markdown déjà là ; ajoute tables/charts. |
+| C4 | **iOS Shortcuts / Siri** : « Dis à Pocket de … » lance une tâche à la voix sans ouvrir l'app. | ⭐⭐ | M | Raccourci → API GitHub. Très « télécommande ». |
+| C5 | **Preview d'écriture structurée** avant approbation (diff clair de ce qui va changer dans HubSpot/…) au lieu d'un texte libre. | ⭐⭐ | M | Renforce la confiance sur les écritures. |
+| C6 | **File d'attente offline** : composer hors-ligne, envoi à la reconnexion. | ⭐ | M | Confort mobile. |
+| C7 | **Push-to-talk** : maintenir pour dicter, relâcher pour envoyer directement. | ⭐ | S | Améliore la voix existante. |
+
+### D. Intelligence & autonomie
+
+| # | Amélioration | Impact | Effort | Notes |
+|---|---|---|---|---|
+| D1 | **Feed proactif** : surfacer dans l'app les sorties des agents existants (morning-briefing, weekly-audit, digest Iris) — un onglet « Fil » avec les rapports. | ⭐⭐⭐ | M | Ces agents tournent déjà ; leurs résultats ne sont pas visibles dans Pocket. Gros levier, faible coût. |
+| D2 | **Routage de modèle** : Haiku/Sonnet pour les lectures simples, Opus pour le complexe → coût maîtrisé, réponses plus rapides. | ⭐⭐ | M | Décision : nécessite tolérance au métré ou reste sur abonnement. |
+| D3 | **Suivi de coût réel** : `total_cost_usd` par run est déjà loggé → agréger un « coût du jour / mois » dans l'onglet Système (vrais chiffres, plus d'estimation). | ⭐⭐ | S | Données déjà disponibles. |
+| D4 | **Knowledge relié au Brain/RAG** : l'agent cite la connaissance utilisée et peut interroger le RAG local `brain.py`. | ⭐ | L | Puissant mais lourd (RAG en CI). |
+
+### E. Observabilité / ops
+
+| # | Amélioration | Impact | Effort | Notes |
+|---|---|---|---|---|
+| E1 | **`pocket-data/status.json`** écrit à chaque run (système touché, succès, coût, durée, dernière erreur) → source de vérité pour A1/D3. | ⭐⭐⭐ | S | Brique transverse : débloque le panneau santé et le suivi coût. |
+| E2 | **Historique coût + durée par tâche** dans le détail. | ⭐ | S | Découle de E1. |
+
+---
+
+## 🚦 Roadmap proposée (séquencée par ROI)
+
+### Phase 0 — Fiabiliser & rendre visible (fondation, ~1-2 j)
+Petit effort, gros retour de confiance. **Prérequis à tout le reste.**
+- **E1** `status.json` par run (brique transverse)
+- **A1** Panneau « Santé des systèmes »
+- **A2** Alerte proactive expiration token
+- **A5** Fix robustesse scheduler
+- **B5** Ajouter `LEMLIST_API_KEY` (débloque outreach immédiatement)
+- **D3** Suivi de coût réel (dérive de E1)
+
+### Phase 1 — Étendre la couverture métier (~3-4 j)
+Rapproche vraiment de « tout piloter depuis le tel ».
+- **B1** Google Ads (fort ROI, auth déjà là)
+- **B2** Gmail (draft de réponse)
+- **D1** Feed proactif (surfacer les agents existants)
+- **A3** Bouton « Relancer »
+
+### Phase 2 — Fluidité & confiance sur l'écriture (~3-4 j)
+- **C5** Preview d'écriture structurée
+- **C2** Bibliothèque de prompts paramétrés
+- **C3** Rendu riche (tables/charts)
+- **B3** Écriture vault
+- **C4** iOS Shortcuts / Siri
+
+### Phase 3 — Raffinements (au besoin)
+- **C1** Streaming temps-réel · **A4** Taxonomie d'erreurs · **D2** Routage modèle
+- **B4** Calendar · **B6** Notion/Slack · **B7** Analytics · **C6/C7** offline/PTT · **D4** RAG
+
+---
+
+## ❓ Décisions à trancher (avant implémentation)
+
+1. **Coût** : rester 100 % abonnement (0 €) ou accepter un métré (`ANTHROPIC_API_KEY`)
+   pour le routage de modèle (D2) et plus de volume ? → conditionne D2, la fréquence
+   des crons, et le choix de modèle par défaut.
+2. **Systèmes prioritaires** : parmi Ads / Gmail / Vault-write / Calendar / Slack /
+   Notion — lesquels d'abord ? (la roadmap parie Ads + Gmail).
+3. **Écriture vault** (B3) : accepte-t-on un PAT en écriture sur le repo vault
+   (garde-fous requis) ?
+4. **Périmètre** : outil solo (statu quo) ou besoin futur de partage/multi-user ?
+
+---
+
+## 🔩 Notes d'implémentation transverses
+- Tout nouveau système = un `scripts/pocket_<systeme>.py` déterministe (REST + stdlib,
+  token via env du step) — **pas** de MCP fragile (leçon plumbing env).
+- Écritures toujours gatées par le label `approved` (pattern existant).
+- Bump du cache SW (`sw.js`) à chaque version front, sinon iOS sert l'ancienne.
+- Push sur `main` bloqué par le classifieur → **branche + PR** systématique.
+- Réindexer le RAG / mettre à jour la mémoire après changements structurels.

--- a/scripts/pocket_health.py
+++ b/scripts/pocket_health.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3.12
+"""Écrit pocket-data/health.json : santé des systèmes Pocket pour le panneau
+de l'app. Vérifie l'auth Claude (résultat d'un run canari) + la présence des
+secrets d'intégration. Pousse une alerte si le token est mort.
+
+Usage: pocket_health.py --token-ok true|false [--exec-file PATH]
+Env: GH_TOKEN, GITHUB_REPOSITORY ; HAS_<SYS>=1/0 pour la présence des secrets ;
+     VAPID_PRIVATE_KEY/VAPID_SUBJECT (optionnel, pour l'alerte push).
+Ne lève jamais (best-effort).
+"""
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+HEALTH_PATH = "pocket-data/health.json"
+API = "https://api.github.com"
+SYSTEMS = ["hubspot", "lemlist", "fullenrich", "phantombuster", "tavily",
+           "firecrawl", "vault", "google_sa"]
+
+
+def _req(method, url, token, data=None):
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("User-Agent", "pocket-health")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.status, json.loads(r.read().decode() or "{}")
+
+
+def read_cost(path):
+    try:
+        data = json.load(open(path))
+    except Exception:
+        return 0.0
+    events = data if isinstance(data, list) else [data]
+    res = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
+    return round(float(res[-1].get("total_cost_usd") or 0), 4) if res else 0.0
+
+
+def get_sha(repo, token):
+    try:
+        _, data = _req("GET", f"{API}/repos/{repo}/contents/{HEALTH_PATH}", token)
+        return data.get("sha")
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--token-ok", required=True)
+    ap.add_argument("--exec-file", default="/home/runner/work/_temp/claude-execution-output.json")
+    args = ap.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("pocket_health: GH_TOKEN/GITHUB_REPOSITORY manquants", file=sys.stderr)
+        return
+
+    token_ok = args.token_ok.lower() == "true"
+    secrets = {s: os.environ.get(f"HAS_{s.upper()}", "0") == "1" for s in SYSTEMS}
+
+    health = {
+        "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "token_ok": token_ok,
+        "model": os.environ.get("CANARY_MODEL", ""),
+        "cost_usd": read_cost(args.exec_file),
+        "secrets": secrets,
+    }
+    content = base64.b64encode(json.dumps(health, indent=2).encode()).decode()
+    body = {"message": "pocket: update health.json", "content": content}
+    sha = get_sha(repo, token)
+    if sha:
+        body["sha"] = sha
+    try:
+        _req("PUT", f"{API}/repos/{repo}/contents/{HEALTH_PATH}", token, body)
+        print(f"pocket_health: écrit (token_ok={token_ok})")
+    except Exception as e:
+        print(f"pocket_health: échec écriture {e}", file=sys.stderr)
+
+    # Alerte push si le token est mort.
+    if not token_ok and os.environ.get("VAPID_PRIVATE_KEY"):
+        try:
+            subprocess.run(
+                ["python3", "scripts/pocket_push.py", "--title", "Claude Pocket ⚠️",
+                 "--body", "Le token Claude est expiré/invalide — renouvelle-le pour réactiver l'agent.",
+                 "--url", "./"],
+                check=False, timeout=60)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pocket_status.py
+++ b/scripts/pocket_status.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3.12
+"""Enregistre le résultat d'un run Pocket dans pocket-data/status.json (via
+Contents API GitHub) : succès/échec, coût réel, durée, système, source.
+
+C'est la source de vérité pour le panneau « Santé des systèmes » et le suivi
+de coût de l'app. Lit le coût/durée/erreur depuis le JSON de sortie de
+claude-code-action ; déduit le système depuis les labels cat:* de l'issue.
+
+Usage: pocket_status.py --issue N [--exec-file PATH]
+Env requis: GH_TOKEN, GITHUB_REPOSITORY. Ne lève jamais (best-effort).
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+EXEC_DEFAULT = "/home/runner/work/_temp/claude-execution-output.json"
+STATUS_PATH = "pocket-data/status.json"
+MAX_RECORDS = 60
+API = "https://api.github.com"
+
+
+def _req(method, url, token, data=None):
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("User-Agent", "pocket-status")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.status, json.loads(r.read().decode() or "{}")
+
+
+def read_exec(path):
+    """Retourne (ok, cost_usd, duration_s) depuis le flux d'événements."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception:
+        return False, 0.0, 0
+    events = data if isinstance(data, list) else [data]
+    results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
+    if not results:
+        return False, 0.0, 0
+    r = results[-1]
+    ok = not r.get("is_error")
+    cost = round(float(r.get("total_cost_usd") or 0), 4)
+    dur = round(float(r.get("duration_ms") or 0) / 1000, 1)
+    return ok, cost, dur
+
+
+def derive_system_source(repo, issue, token):
+    system, source = "other", "phone"
+    try:
+        _, data = _req("GET", f"{API}/repos/{repo}/issues/{issue}", token)
+        names = [l.get("name", "") for l in data.get("labels", [])]
+        for n in names:
+            if n.startswith("cat:"):
+                system = n[4:]
+                break
+        if "via:phone" in names:
+            source = "phone"
+        elif any(n == "scheduled" for n in names):
+            source = "scheduled"
+    except Exception:
+        pass
+    return system, source
+
+
+def load_status(repo, token):
+    """Retourne (records, sha) ; sha=None si le fichier n'existe pas."""
+    try:
+        _, data = _req("GET", f"{API}/repos/{repo}/contents/{STATUS_PATH}", token)
+        content = base64.b64decode(data.get("content", "")).decode()
+        obj = json.loads(content)
+        return obj.get("runs", []), data.get("sha")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return [], None
+        raise
+    except Exception:
+        return [], None
+
+
+def save_status(repo, token, runs, sha):
+    payload = {
+        "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "runs": runs[-MAX_RECORDS:],
+    }
+    content = base64.b64encode(json.dumps(payload, indent=2).encode()).decode()
+    body = {"message": "pocket: update status.json", "content": content}
+    if sha:
+        body["sha"] = sha
+    _req("PUT", f"{API}/repos/{repo}/contents/{STATUS_PATH}", token, body)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--issue", required=True)
+    ap.add_argument("--exec-file", default=EXEC_DEFAULT)
+    args = ap.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("pocket_status: GH_TOKEN/GITHUB_REPOSITORY manquants", file=sys.stderr)
+        return
+
+    ok, cost, dur = read_exec(args.exec_file)
+    system, source = derive_system_source(repo, args.issue, token)
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "issue": int(args.issue) if str(args.issue).isdigit() else args.issue,
+        "system": system,
+        "source": source,
+        "ok": ok,
+        "cost_usd": cost,
+        "duration_s": dur,
+    }
+
+    # Retry sur conflit 409 (runs concurrents) : recharge le sha et réessaie.
+    for attempt in range(3):
+        try:
+            runs, sha = load_status(repo, token)
+            runs.append(record)
+            save_status(repo, token, runs, sha)
+            print(f"pocket_status: enregistré {record}")
+            return
+        except urllib.error.HTTPError as e:
+            if e.code == 409 and attempt < 2:
+                time.sleep(1 + attempt)
+                continue
+            print(f"pocket_status: échec HTTP {e.code}", file=sys.stderr)
+            return
+        except Exception as e:
+            print(f"pocket_status: {e}", file=sys.stderr)
+            return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 0 — Fondation (fiabiliser & rendre visible)

Première tranche de la roadmap (`docs/pocket/ROADMAP.md`). Backend testable, aucun risque front.

### Ajouts
- **`pocket_status.py`** → `pocket-data/status.json` : chaque run enregistre ok / **coût réel** / durée / système (Contents API, retry sur 409). Source de vérité pour le panneau Santé + suivi de coût (E1/D3).
- **`pocket_health.py` + `pocket-health.yml`** : canari toutes les 6 h qui teste le token OAuth et la présence des secrets → `pocket-data/health.json` + **alerte push si le token est mort** (A2 — plus jamais de panne d'auth silencieuse).
- **`pocket-schedule.yml`** : correctif anti-échec-silencieux identique à pocket.yml (A5).
- **`pocket.yml`** : étape Record status.
- Secret **`LEMLIST_API_KEY`** ajouté hors-PR (pilier outreach débloqué, B5).

Décisions par défaut : 0 €/abonnement, priorité Ads+Gmail (Phase 1), vault-write reporté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen Pocket’s reliability and observability by recording run status and costs, adding scheduled health checks for auth and integration secrets, and hardening the scheduler against silent failures.

Enhancements:
- Track each Pocket run’s outcome, duration, system, source, and real cost into pocket-data/status.json for use by health and cost dashboards.
- Generate pocket-data/health.json via a periodic canary workflow that validates Claude auth and the presence of integration secrets, feeding the app’s health panel.

CI:
- Enhance the scheduled Pocket workflow to detect silent agent failures, post fallback comments and push notifications on auth issues, record run status, and explicitly fail runs when Claude errors.

Documentation:
- Add a Pocket roadmap document outlining vision, gaps, and phased improvement plan for reliability, coverage, UX, and observability.