### PR TITLE
feat(pocket): v16 — refonte complète de l'interface (Claude mobile)

### DIFF
--- a/docs/pocket/app.js
+++ b/docs/pocket/app.js
@@ -1,76 +1,70 @@
 'use strict';
 
 const VAPID_PUBLIC = 'BBrWaeSczwSz-wCywXN0OlFQ72UdUWRLLeAU9fjzD_8uw7saPxizhDNu6jTfe4xM4hbk_pV0GoAVxoTMD6BZpTw';
-const MODEL = 'claude-opus-4-8';
-const APP_VERSION = 'v15';
-const CTX_WINDOW = 200000; // fenêtre de contexte (tokens) du modèle
-function estTokens(text) { return Math.round((text || '').length / 4); }
-function slugify(s) { return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40); }
-function decodeB64(c) { try { return decodeURIComponent(escape(atob((c || '').replace(/\s/g, '')))); } catch { return ''; } }
+const APP_VERSION = 'v16';
+const CTX_WINDOW = 200000;
+const MODELS = { fable: 'Fable 5', opus: 'Opus 4.8', sonnet: 'Sonnet' };
 const CATS = {
-  'cat:crm': { label: 'CRM', color: '#3b6fd4' },
-  'cat:enrich': { label: 'Enrichissement', color: '#8957e5' },
-  'cat:outreach': { label: 'Outreach', color: '#2da44e' },
-  'cat:web': { label: 'Web', color: '#bf8700' },
-  'cat:vault': { label: 'Vault', color: '#1f8f9a' },
-  'cat:code': { label: 'Code', color: '#bf3989' },
-  'cat:other': { label: 'Autre', color: '#57606a' },
+  'cat:crm': { label: 'CRM', color: '#c96442' },
+  'cat:enrich': { label: 'Enrichissement', color: '#b8863a' },
+  'cat:content': { label: 'Contenu', color: '#8a6d9c' },
+  'cat:web': { label: 'Web', color: '#4f8a8b' },
+  'cat:vault': { label: 'Vault', color: '#6d8a4f' },
+  'cat:other': { label: 'Autre', color: '#8a7f70' },
 };
+const MCP_BASE = [
+  { name: 'github', desc: 'Repo & issues', badge: 'base' },
+  { name: 'hubspot', desc: 'CRM (lecture + écriture gatée)', badge: 'base' },
+  { name: 'tavily', desc: 'Recherche web', badge: 'base' },
+  { name: 'firecrawl', desc: 'Scraping web', badge: 'base' },
+];
+
+function estTokens(t) { return Math.round((t || '').length / 4); }
+function decodeB64(c) { try { return decodeURIComponent(escape(atob((c || '').replace(/\s/g, '')))); } catch { return ''; } }
+function b64(s) { return btoa(unescape(encodeURIComponent(s))); }
 
 const LS = {
   get repo() { return localStorage.getItem('pocket_repo') || ''; }, set repo(v) { localStorage.setItem('pocket_repo', v); },
   get pat() { return localStorage.getItem('pocket_pat') || ''; }, set pat(v) { localStorage.setItem('pocket_pat', v); },
-  get history() { try { return JSON.parse(localStorage.getItem('pocket_history') || '[]'); } catch { return []; } },
-  set history(v) { localStorage.setItem('pocket_history', JSON.stringify(v.slice(0, 50))); },
   get device() { let d = localStorage.getItem('pocket_device'); if (!d) { d = 'dev-' + Math.random().toString(36).slice(2, 10); localStorage.setItem('pocket_device', d); } return d; },
   get theme() { return localStorage.getItem('pocket_theme') || 'auto'; }, set theme(v) { localStorage.setItem('pocket_theme', v); },
+  get model() { return localStorage.getItem('pocket_model') || 'opus'; }, set model(v) { localStorage.setItem('pocket_model', v); },
 };
 const $ = (id) => document.getElementById(id);
-let pollTimer = null, allIssues = [], currentFilter = 'all', connectedLogin = '', detailNum = null, attachedFiles = [];
-let allModes = [], selectedMode = 'auto', editingMode = null;
-let currentSource = 'phone', currentView = 'main', mainTimer = null;
-
-// Origine d'une tâche : téléphone (app), programmé (cron), ou ordinateur (Claude Code).
-function taskSource(issue) {
-  const labels = (issue.labels || []).map((l) => l.name || l);
-  if (labels.includes('via:phone')) return 'phone';
-  const a = issue.user && issue.user.login;
-  if ((issue.title || '').includes('⏰')) return 'scheduled';
-  if (a && /github-actions/i.test(a)) return 'scheduled';
-  if (a && connectedLogin && a === connectedLogin) return 'phone';
-  return 'computer';
-}
+let pollTimer = null, mainTimer = null, allIssues = [], currentView = 'home';
+let connectedLogin = '', detailNum = null, attachedFiles = [], selectedModel = LS.model;
+let mcpServers = [], editingMcp = null;
 
 // ── API GitHub ──────────────────────────────────────────────────────────────
 async function gh(path, opts = {}) {
-  if (!LS.pat || !LS.repo) throw new Error('Configure le repo et le token (engrenage).');
+  if (!LS.pat || !LS.repo) throw new Error('Configure le repo et le token (Administration).');
   const res = await fetch(`https://api.github.com/repos/${LS.repo}${path}`, {
     ...opts, headers: { 'Authorization': `Bearer ${LS.pat}`, 'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28', 'Content-Type': 'application/json', ...(opts.headers || {}) },
   });
   if (!res.ok) { let d = ''; try { d = (await res.json()).message || ''; } catch {} const e = new Error(`GitHub ${res.status} ${d}`.trim()); e.status = res.status; throw e; }
   return res.status === 204 ? null : res.json();
 }
-// Lit un fichier JSON du repo (Contents API + décodage b64). null si absent.
 async function ghJSON(path) { try { const r = await gh('/contents/' + path); return JSON.parse(decodeB64(r.content)); } catch { return null; } }
+async function putJSON(path, obj, msg) {
+  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
+  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: msg || `pocket: ${path}`, content: b64(JSON.stringify(obj, null, 2)), sha }) });
+}
+async function putRaw(path, content) {
+  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
+  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: upload ${path}`, content, sha }) });
+}
 function friendlyError(e) {
-  if (e.status === 403) return `${e.message}\n→ Token « classic » (scope repo) du compte gcoche-bit requis + accès écriture au repo.`;
+  if (e.status === 403) return `${e.message}\n→ Token « classic » (scope repo) requis + accès écriture au repo.`;
   if (e.status === 401) return `${e.message}\n→ Token invalide/expiré.`;
   return e.message;
 }
-function b64(s) { return btoa(unescape(encodeURIComponent(s))); }
-async function putFile(path, obj) {
-  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
-  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: sub ${LS.device}`, content: b64(JSON.stringify(obj, null, 2)), sha }) });
-}
-async function putRaw(path, b64content) {
-  let sha; try { sha = (await gh(`/contents/${path}`)).sha; } catch {}
-  await gh(`/contents/${path}`, { method: 'PUT', body: JSON.stringify({ message: `pocket: upload ${path}`, content: b64content, sha }) });
-}
+function escapeHtml(s) { return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }
+function timeago(iso) { const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 60) return "à l'instant"; if (s < 3600) return `il y a ${Math.floor(s / 60)} min`; if (s < 86400) return `il y a ${Math.floor(s / 3600)} h`; return `il y a ${Math.floor(s / 86400)} j`; }
 
-// ── Import de fichiers ──────────────────────────────────────────────────────
+// ── Fichiers ──────────────────────────────────────────────────────────────
 function addFiles(fileList) {
   for (const f of fileList) {
-    if (f.size > 4 * 1024 * 1024) { alert(`${f.name} dépasse 4 Mo — ignoré.`); continue; }
+    if (f.size > 4 * 1024 * 1024) { flash('composer-msg', `${f.name} dépasse 4 Mo — ignoré.`, 'err'); continue; }
     const r = new FileReader();
     r.onload = () => { attachedFiles.push({ name: f.name, size: f.size, b64: String(r.result).split(',')[1] || '' }); renderFileList(); };
     r.readAsDataURL(f);
@@ -81,243 +75,103 @@ function renderFileList() {
   attachedFiles.forEach((f, i) => {
     const kb = Math.max(1, Math.round(f.size / 1024));
     const row = document.createElement('div'); row.className = 'file-row';
-    row.innerHTML = `<span class="fx">📎 ${escapeHtml(f.name)} · ${kb} Ko</span><button title="Retirer">×</button>`;
+    row.innerHTML = `<span class="fx"><svg class="ic"><use href="#i-clip"/></svg>${escapeHtml(f.name)} · ${kb} Ko</span><button title="Retirer">&times;</button>`;
     row.querySelector('button').onclick = () => { attachedFiles.splice(i, 1); renderFileList(); };
     el.appendChild(row);
   });
 }
 async function ensureLabels() {
-  const labels = [['pocket', '8b5cf6'], ['approved', '3fb950'], ['via:phone', '0a84ff'], ...Object.entries(CATS).map(([k, v]) => [k, v.color.replace('#', '')])];
+  const labels = [['pocket', 'c96442'], ['approved', '5c8a44'], ['via:phone', 'b8863a'], ...Object.entries(CATS).map(([k, v]) => [k, v.color.replace('#', '')])];
   for (const [name, color] of labels) { try { await gh('/labels', { method: 'POST', body: JSON.stringify({ name, color }) }); } catch {} }
 }
 
 // ── Dispatch ────────────────────────────────────────────────────────────────
 function buildBody(d, w, c) {
-  return ['### Demande', '', d, '', "### Autoriser l'écriture ?", '', w ? 'oui' : 'non', '', "### Conditions d'écriture (si OUI)", '', c || '_No response_', '', '### Workflow (recette)', '', 'auto', '', '### Agent (optionnel)', '', 'auto', ''].join('\n');
+  return ['### Demande', '', d, '', "### Autoriser l'écriture ?", '', w ? 'oui' : 'non', '',
+    "### Conditions d'écriture (si OUI)", '', c || '_No response_', '',
+    '### Modèle', '', selectedModel, ''].join('\n');
 }
 async function dispatch() {
   const demande = $('demande').value.trim(); const msg = $('composer-msg');
-  if (!demande) { msg.className = 'msg err'; msg.textContent = 'Écris une demande.'; return; }
+  if (!demande) { flash('composer-msg', 'Écris une demande.', 'err'); return; }
   const w = $('write-allowed').checked, c = $('conditions').value.trim();
-  msg.className = 'msg'; msg.textContent = 'Envoi…';
+  flash('composer-msg', 'Envoi…');
   try {
     await ensureLabels();
     let attachNote = '';
     if (attachedFiles.length) {
-      msg.textContent = 'Envoi des fichiers…';
+      flash('composer-msg', 'Envoi des fichiers…');
       const paths = [];
       for (const f of attachedFiles) {
         const path = `pocket-data/uploads/${Date.now()}-${f.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
         await putRaw(path, f.b64); paths.push(path);
       }
       attachNote = '\n\n### Fichiers joints\n' + paths.map((p) => '- `' + p + '` (lis-le avec `cat ' + p + '`)').join('\n');
-      msg.textContent = 'Envoi…';
     }
     const title = '[Pocket] ' + demande.slice(0, 60).replace(/\n/g, ' ');
-    const modeNote = '\n\n### Mode\n\n' + (selectedMode || 'auto');
-    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c) + modeNote + attachNote, labels: ['pocket', 'via:phone'] }) });
+    const issue = await gh('/issues', { method: 'POST', body: JSON.stringify({ title, body: buildBody(demande, w, c) + attachNote, labels: ['pocket', 'via:phone'] }) });
     $('demande').value = ''; $('conditions').value = ''; $('write-allowed').checked = false; $('conditions-wrap').classList.add('hidden');
     attachedFiles = []; renderFileList();
-    msg.className = 'msg ok'; msg.textContent = `Tâche #${issue.number} envoyée.`;
+    flash('composer-msg', `Conversation #${issue.number} lancée.`, 'ok');
     navigate('detail:' + issue.number);
-  } catch (e) { msg.className = 'msg err'; msg.textContent = friendlyError(e); }
+  } catch (e) { flash('composer-msg', friendlyError(e), 'err'); }
 }
+function flash(id, text, cls) { const m = $(id); if (!m) return; m.className = 'msg' + (cls ? ' ' + cls : ''); m.textContent = text; }
 
-// ── Historique classé par système ───────────────────────────────────────────
-function issueCat(issue) { const l = (issue.labels || []).map((x) => x.name || x).find((n) => n.startsWith('cat:')); return l || null; }
+// ── Accueil : conversations récentes ─────────────────────────────────────────
+function issueCat(i) { const l = (i.labels || []).map((x) => x.name || x).find((n) => n.startsWith('cat:')); return l || null; }
 async function loadHistory() {
-  try { allIssues = await gh('/issues?labels=pocket&state=all&per_page=60&sort=created&direction=desc'); }
-  catch { allIssues = LS.history.map((h) => ({ number: h.number, title: h.title, labels: [], state: 'open' })); }
-  renderSourceFilter(); renderFilters(); renderHistory(); renderDashboard();
+  try { allIssues = await gh('/issues?labels=pocket&state=all&per_page=40&sort=created&direction=desc'); } catch { allIssues = []; }
+  renderMiniStats(); renderHistory();
 }
-function bySource(items) { return currentSource === 'all' ? items : items.filter((i) => taskSource(i) === currentSource); }
-function renderSourceFilter() {
-  for (const b of document.querySelectorAll('#source-filter button')) b.classList.toggle('active', b.dataset.src === currentSource);
-}
-function renderFilters() {
-  const present = new Set(bySource(allIssues).map(issueCat).filter(Boolean));
-  const el = $('cat-filters'); el.innerHTML = '';
-  const mk = (key, label) => { const b = document.createElement('button'); b.className = 'chip' + (currentFilter === key ? ' active' : ''); b.textContent = label; b.onclick = () => { currentFilter = key; renderFilters(); renderHistory(); }; return b; };
-  el.appendChild(mk('all', 'Tout'));
-  for (const k of Object.keys(CATS)) if (present.has(k)) el.appendChild(mk(k, CATS[k].label));
-}
-async function renderDashboard() {
-  const items = bySource(allIssues);
+async function renderMiniStats() {
   const today = new Date().toDateString();
-  const todayN = items.filter((i) => i.created_at && new Date(i.created_at).toDateString() === today).length;
+  const todayN = allIssues.filter((i) => i.created_at && new Date(i.created_at).toDateString() === today).length;
   let running = 0;
-  try { const r = await gh('/actions/workflows/pocket.yml/runs?status=in_progress&per_page=30'); running = (r.workflow_runs || []).length; } catch {}
-  $('dash-stats').innerHTML =
-    `<div class="ds"><div class="dsv ${running ? 'live' : ''}">${running}</div><div class="dsk">en cours</div></div>` +
-    `<div class="ds"><div class="dsv">${todayN}</div><div class="dsk">aujourd'hui</div></div>` +
-    `<div class="ds"><div class="dsv">${items.length}</div><div class="dsk">total</div></div>`;
-  const counts = {};
-  for (const i of items) { const c = issueCat(i) || 'cat:other'; counts[c] = (counts[c] || 0) + 1; }
-  const el = $('dash-domains'); el.innerHTML = '';
-  for (const [c, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
-    const cm = CATS[c] || CATS['cat:other'];
-    const chip = document.createElement('button'); chip.className = 'dchip' + (currentFilter === c ? ' active' : '');
-    chip.innerHTML = `<span class="ddot" style="background:${cm.color}"></span>${cm.label} <b>${n}</b>`;
-    chip.onclick = () => { currentFilter = currentFilter === c ? 'all' : c; renderFilters(); renderHistory(); renderDashboard(); $('history').scrollIntoView({ behavior: 'smooth' }); };
-    el.appendChild(chip);
-  }
+  try { const r = await gh('/actions/workflows/pocket.yml/runs?status=in_progress&per_page=20'); running = (r.workflow_runs || []).length; } catch {}
+  $('mini-stats').innerHTML =
+    (running ? `<span class="live"><b>${running}</b> en cours</span>` : '') +
+    `<span><b>${todayN}</b> aujourd'hui</span><span><b>${allIssues.length}</b> total</span>`;
 }
 function renderHistory() {
   const ul = $('history-list'); ul.innerHTML = '';
-  let items = bySource(allIssues); if (currentFilter !== 'all') items = items.filter((i) => issueCat(i) === currentFilter);
-  if (!items.length) { ul.innerHTML = '<li class="empty">Aucune tâche dans cette vue.</li>'; return; }
-  for (const i of items) {
+  if (!allIssues.length) { ul.innerHTML = '<li class="empty">Aucune conversation. Lance ta première tâche ci-dessus.</li>'; return; }
+  for (const i of allIssues) {
     const cat = issueCat(i) || 'cat:other'; const cm = CATS[cat] || CATS['cat:other'];
-    const li = document.createElement('li');
-    li.style.setProperty('--cat', cm.color);
-    li.innerHTML = `<span class="t">#${i.number} ${escapeHtml((i.title || '').replace('[Pocket] ', ''))}</span>
+    const li = document.createElement('li'); li.style.setProperty('--cat', cm.color);
+    li.innerHTML = `<span class="t">${escapeHtml((i.title || '').replace('[Pocket] ', ''))}</span>
       <span class="meta-r"><span class="cat-badge" style="background:${cm.color}">${cm.label}</span>
-      <span class="badge ${i.state === 'open' ? 'open' : 'pending'}">${i.state === 'open' ? '●' : '✓'}</span></span>`;
+      <span class="st ${i.state === 'open' ? 'open' : 'done'}"></span></span>`;
     li.onclick = () => navigate('detail:' + i.number);
     ul.appendChild(li);
   }
 }
 
-// ── Modes agentiques (CRUD via repo) ────────────────────────────────────────
-async function loadModes() {
-  try {
-    const items = await gh('/contents/pocket-modes');
-    const files = (Array.isArray(items) ? items : []).filter((f) => f.name.endsWith('.json'));
-    const out = [];
-    for (const f of files) {
-      try { const c = await gh('/contents/' + f.path); const o = JSON.parse(decodeB64(c.content)); o._sha = c.sha; out.push(o); } catch {}
-    }
-    allModes = out.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-  } catch { allModes = []; }
-  renderModeChips();
-}
-function renderModeChips() {
-  const el = $('mode-chips'); if (!el) return; el.innerHTML = '';
-  const mk = (slug, label) => { const b = document.createElement('button'); b.className = 'chip' + (selectedMode === slug ? ' active' : ''); b.textContent = label; b.onclick = () => { selectedMode = slug; renderModeChips(); }; return b; };
-  el.appendChild(mk('auto', '⚡ Généraliste'));
-  for (const m of allModes) el.appendChild(mk(m.slug, m.name));
-}
-function renderModes() {
-  const ul = $('modes-list'); ul.innerHTML = '';
-  if (!allModes.length) { ul.innerHTML = '<li class="empty">Aucun mode pour l\'instant. Crée ton premier agent.</li>'; return; }
-  for (const m of allModes) {
-    const cm = CATS[m.category] || CATS['cat:other'];
-    const li = document.createElement('li'); li.style.setProperty('--cat', cm.color);
-    li.innerHTML = `<div class="mh"><div><div class="mn">${escapeHtml(m.name)}</div><div class="md">${escapeHtml(m.description || '')}</div></div><div class="actions"><button class="edit">Éditer</button></div></div>`;
-    li.querySelector('.edit').onclick = () => openModeEditor(m);
-    ul.appendChild(li);
-  }
-}
-async function openModeEditor(mode) {
-  editingMode = mode || null;
-  $('mode-editor').classList.remove('hidden');
-  $('mode-name').value = mode ? mode.name : '';
-  $('mode-cat').value = mode ? mode.category : 'cat:other';
-  $('mode-desc').value = mode ? mode.description : '';
-  $('mode-instr').value = mode ? mode.instructions : '';
-  $('mode-delete').classList.toggle('hidden', !mode);
-  $('mode-msg').textContent = '';
-  // Programmation : reset puis charge si existante
-  $('mode-freq').value = 'none'; $('sched-extra').classList.add('hidden'); $('weekday-wrap').classList.add('hidden');
-  $('mode-time').value = '08:00'; $('mode-sched-demande').value = '';
-  if (mode) {
-    try {
-      const c = await gh('/contents/pocket-schedules/' + mode.slug + '.json');
-      const sc = JSON.parse(decodeB64(c.content));
-      $('mode-freq').value = sc.freq; $('sched-extra').classList.remove('hidden');
-      $('mode-time').value = String(sc.hour).padStart(2, '0') + ':' + String(sc.minute || 0).padStart(2, '0');
-      $('mode-weekday').value = sc.weekday || 0; $('mode-sched-demande').value = sc.demande || '';
-      $('weekday-wrap').classList.toggle('hidden', sc.freq !== 'weekly');
-    } catch {}
-  }
-  // Chaînage : liste des autres modes
-  const chainSel = $('mode-chain'); chainSel.innerHTML = '<option value="">Aucun</option>';
-  for (const m of allModes) if (!mode || m.slug !== mode.slug) chainSel.appendChild(new Option(m.name, m.slug));
-  chainSel.value = (mode && mode.chain_to) ? mode.chain_to : '';
-  $('mode-editor').scrollIntoView({ behavior: 'smooth' });
-}
-async function saveSchedule(slug, name, cat) {
-  const path = 'pocket-schedules/' + slug + '.json';
-  const freq = $('mode-freq').value;
-  if (freq === 'none') {
-    try { const c = await gh('/contents/' + path); await gh('/contents/' + path, { method: 'DELETE', body: JSON.stringify({ message: 'pocket: unschedule ' + slug, sha: c.sha }) }); } catch {}
-    return;
-  }
-  const [hh, mm] = ($('mode-time').value || '08:00').split(':');
-  const obj = { id: slug, mode: slug, name, category: cat, freq, hour: parseInt(hh, 10), minute: parseInt(mm, 10), weekday: parseInt($('mode-weekday').value, 10), demande: $('mode-sched-demande').value.trim() || ('Lance le mode ' + name + '.'), enabled: true, tz: 'Europe/Brussels', last_fired: '' };
-  let sha; try { sha = (await gh('/contents/' + path)).sha; } catch {}
-  await gh('/contents/' + path, { method: 'PUT', body: JSON.stringify({ message: 'pocket: schedule ' + slug, content: b64(JSON.stringify(obj, null, 2)), sha }) });
-}
-async function saveMode() {
-  const name = $('mode-name').value.trim(), instr = $('mode-instr').value.trim(), m = $('mode-msg');
-  if (!name || !instr) { m.className = 'msg err'; m.textContent = 'Nom et instructions requis.'; return; }
-  const slug = editingMode ? editingMode.slug : slugify(name);
-  const obj = { name, slug, category: $('mode-cat').value, description: $('mode-desc').value.trim(), instructions: instr, created: editingMode ? editingMode.created : Date.now() };
-  if ($('mode-chain').value) obj.chain_to = $('mode-chain').value;
-  m.className = 'msg'; m.textContent = 'Déploiement…';
-  try {
-    let sha = editingMode ? editingMode._sha : undefined;
-    if (!sha) { try { sha = (await gh('/contents/pocket-modes/' + slug + '.json')).sha; } catch {} }
-    await gh('/contents/pocket-modes/' + slug + '.json', { method: 'PUT', body: JSON.stringify({ message: 'pocket: mode ' + slug, content: b64(JSON.stringify(obj, null, 2)), sha }) });
-    await saveSchedule(slug, name, obj.category);
-    m.className = 'msg ok'; m.textContent = '✅ Mode déployé' + ($('mode-freq').value !== 'none' ? ' + programmé.' : ' — utilisable au lancement d\'une tâche.');
-    $('mode-editor').classList.add('hidden');
-    await loadModes(); renderModes();
-  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-}
-async function deleteMode() {
-  if (!editingMode) return; const m = $('mode-msg'); m.className = 'msg'; m.textContent = 'Suppression…';
-  try {
-    await gh('/contents/pocket-modes/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: delete mode ' + editingMode.slug, sha: editingMode._sha }) });
-    try { const c = await gh('/contents/pocket-schedules/' + editingMode.slug + '.json'); await gh('/contents/pocket-schedules/' + editingMode.slug + '.json', { method: 'DELETE', body: JSON.stringify({ message: 'pocket: unschedule ' + editingMode.slug, sha: c.sha }) }); } catch {}
-    if (selectedMode === editingMode.slug) selectedMode = 'auto';
-    $('mode-editor').classList.add('hidden'); await loadModes(); renderModes();
-  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-}
-
-// ── Connaissances (expertise) ────────────────────────────────────────────────
-let knowSha = {};
-async function loadKnowledge() {
-  const domain = $('know-domain').value; $('know-msg').textContent = ''; $('know-text').value = 'Chargement…';
-  try { const c = await gh('/contents/pocket-knowledge/' + domain + '.md'); $('know-text').value = decodeB64(c.content); knowSha[domain] = c.sha; }
-  catch { $('know-text').value = ''; knowSha[domain] = null; }
-}
-async function saveKnowledge() {
-  const domain = $('know-domain').value, m = $('know-msg'); m.className = 'msg'; m.textContent = 'Enregistrement…';
-  try {
-    const body = { message: 'knowledge: ' + domain + ' (édition manuelle)', content: b64($('know-text').value) };
-    if (knowSha[domain]) body.sha = knowSha[domain];
-    const r = await gh('/contents/pocket-knowledge/' + domain + '.md', { method: 'PUT', body: JSON.stringify(body) });
-    knowSha[domain] = r.content.sha; m.className = 'msg ok'; m.textContent = '✅ Enregistré.';
-  } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-}
-
-// ── Monitoring run ──────────────────────────────────────────────────────────
-const STEP_LABELS = { 'Set up job': 'Préparation', 'Run actions/checkout@v4': 'Récupération du code', 'Install MCP servers': 'Installation des outils', 'Run actions/setup-python@v5': 'Préparation Python', 'Write task to disk': 'Lecture de la demande', 'Write MCP config with secrets': 'Connexion aux apps', 'Build claude_args': 'Configuration', 'Run Claude Pocket': 'Claude travaille', 'Notify (push)': 'Notification' };
-async function findRun(title) {
-  try { const d = await gh(`/actions/workflows/pocket.yml/runs?per_page=30`); const runs = (d.workflow_runs || []).filter((r) => r.display_title === title); runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); return runs[0] || null; } catch { return null; }
-}
+// ── Conversation (détail + chat) ─────────────────────────────────────────────
+const STEP_LABELS = { 'Set up job': 'Préparation', 'Install MCP servers': 'Installation des outils', 'Write task to disk': 'Lecture de la demande', 'Write MCP config with secrets': 'Connexion aux systèmes', 'Build claude_args': 'Configuration', 'Run Claude Pocket': 'Claude travaille', 'Check Claude result': 'Vérification', 'Notify (push)': 'Notification' };
 function fmtDur(s, e) { if (!s) return '—'; const x = Math.max(0, ((e ? new Date(e) : new Date()) - new Date(s)) / 1000); return x < 60 ? `${Math.round(x)}s` : `${Math.floor(x / 60)}m${Math.round(x % 60)}s`; }
 function cell(k, icon, v) { return `<div class="kcell"><div class="k"><svg class="ic"><use href="#${icon}"/></svg>${k}</div><div class="v sm">${v}</div></div>`; }
+async function findRun(title) {
+  try { const d = await gh('/actions/workflows/pocket.yml/runs?per_page=30'); const runs = (d.workflow_runs || []).filter((r) => r.display_title === title); runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)); return runs[0] || null; } catch { return null; }
+}
+function isProgress(text) { const t = (text || '').trim(); return t.length < 170 && !/\n\n/.test(t) && /^(compris|je\s|j'|d'accord|ok\b)/i.test(t); }
 async function renderRunStatus(run) {
   const bar = $('run-status');
-  if (!run) { bar.className = 'status-bar idle'; bar.textContent = 'Démarrage…'; return null; }
-  if (run.status === 'queued') { bar.className = 'status-bar queued'; bar.textContent = 'En file…'; return null; }
-  if (run.status === 'completed') { bar.className = 'status-bar ' + (run.conclusion === 'success' ? 'ok' : (run.conclusion === 'cancelled' ? 'idle' : 'err')); bar.textContent = run.conclusion === 'success' ? 'Terminé' : (run.conclusion === 'cancelled' ? 'Annulé' : 'Terminé avec un souci'); return null; }
+  if (!run) { bar.className = 'status-pill idle'; bar.textContent = 'En attente'; return null; }
+  if (run.status === 'queued') { bar.className = 'status-pill queued'; bar.textContent = 'En file'; return null; }
+  if (run.status === 'completed') { bar.className = 'status-pill ' + (run.conclusion === 'success' ? 'ok' : (run.conclusion === 'cancelled' ? 'idle' : 'err')); bar.textContent = run.conclusion === 'success' ? 'Terminé' : (run.conclusion === 'cancelled' ? 'Annulé' : 'Échec'); return null; }
   let step = 'Claude travaille', jobs = null;
   try { jobs = await gh(`/actions/runs/${run.id}/jobs`); const job = (jobs.jobs || []).find((j) => j.status === 'in_progress') || (jobs.jobs || [])[0]; const cur = job && (job.steps || []).find((s) => s.status === 'in_progress'); if (cur) step = STEP_LABELS[cur.name] || cur.name; } catch {}
-  bar.className = 'status-bar running'; bar.textContent = step + '…'; return jobs;
+  bar.className = 'status-pill running'; bar.textContent = step; return jobs;
 }
 async function renderMonitor(run, jobs, usage) {
-  const el = $('monitor');
-  const u = usage || { tokens: 0, pct: 0 };
+  const el = $('monitor'); const u = usage || { tokens: 0, pct: 0 };
   let h = '<div class="kgrid">';
-  h += cell('Modèle', 'i-brain', MODEL) + cell('Agent', 'i-robot', 'Claude Pocket');
+  h += cell('Modèle', 'i-brain', MODELS[selectedModel] || 'Opus 4.8');
   h += cell('Statut', 'i-info', run ? (run.status === 'completed' ? (run.conclusion || 'fini') : run.status) : '—');
   h += cell('Durée', 'i-clock', run ? fmtDur(run.run_started_at, run.status === 'completed' ? run.updated_at : null) : '—');
-  h += cell('Tokens (estim.)', 'i-brain', '≈ ' + u.tokens.toLocaleString('fr-FR'));
   h += cell('Contexte', 'i-brain', u.pct.toFixed(1) + '% de 200K');
-  h += `<div class="kcell wide"><div class="k"><svg class="ic"><use href="#i-brain"/></svg>Remplissage du contexte</div><div class="gauge ${u.pct > 80 ? 'warn' : ''}"><i style="width:${Math.min(100, u.pct)}%"></i></div></div></div>`;
+  h += '</div>';
   if (!jobs && run && run.status !== 'completed') { try { jobs = await gh(`/actions/runs/${run.id}/jobs`); } catch {} }
   const job = jobs && ((jobs.jobs || []).find((j) => j.name && j.name.includes('pocket')) || (jobs.jobs || [])[0]);
   if (job && job.steps) {
@@ -325,18 +179,16 @@ async function renderMonitor(run, jobs, usage) {
     for (const s of job.steps.filter((s) => STEP_LABELS[s.name])) {
       const cls = s.status === 'in_progress' ? 'cur' : (s.conclusion === 'success' ? 'done' : '');
       const dur = (s.started_at && s.completed_at) ? Math.max(1, Math.round((new Date(s.completed_at) - new Date(s.started_at)) / 1000)) + 's' : '';
-      h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}${dur ? '<span style="margin-left:auto;color:var(--muted);font-size:11px">' + dur + '</span>' : ''}</div>`;
+      h += `<div class="step ${cls}"><span class="sdot"></span>${STEP_LABELS[s.name]}${dur ? '<span style="margin-left:auto">' + dur + '</span>' : ''}</div>`;
     }
     h += '</div>';
   }
   el.innerHTML = h;
 }
-
-// ── Détail + chat ───────────────────────────────────────────────────────────
 function loadDetail(number) {
   stopPoll(); detailNum = number;
-  $('detail-title').textContent = `Tâche #${number}`;
-  $('run-status').className = 'status-bar idle'; $('run-status').textContent = 'Chargement…';
+  $('detail-title').textContent = `Conversation #${number}`;
+  $('run-status').className = 'status-pill idle'; $('run-status').textContent = 'Chargement';
   $('monitor').innerHTML = ''; $('comments').innerHTML = ''; $('approve').classList.add('hidden'); $('detail-msg').textContent = '';
   const load = async () => {
     if (detailNum !== number) return;
@@ -344,13 +196,11 @@ function loadDetail(number) {
       const [issue, comments] = await Promise.all([gh(`/issues/${number}`), gh(`/issues/${number}/comments?per_page=100`)]);
       const approved = (issue.labels || []).map((l) => l.name).includes('approved');
       const threadText = (issue.body || '') + comments.map((c) => c.body).join('\n');
-      const tokens = estTokens(threadText);
-      const usage = { tokens, pct: Math.min(100, tokens / CTX_WINDOW * 100) };
+      const usage = { tokens: estTokens(threadText), pct: Math.min(100, estTokens(threadText) / CTX_WINDOW * 100) };
       const run = await findRun(issue.title);
       const jobs = await renderRunStatus(run);
       await renderMonitor(run, jobs, usage);
-      // Activité en direct (dernier message de progression) + lien logs bruts
-      const prog = comments.filter((cm) => cm.user.type !== 'User' && /^▶️|^🔎|^📊|^🧠|^⏳|m'en occupe/i.test(cm.body.trim()));
+      const prog = comments.filter((cm) => cm.user.type !== 'User' && isProgress(cm.body));
       const la = $('live-activity');
       if (run && run.status !== 'completed' && prog.length) { la.classList.remove('hidden'); la.textContent = prog[prog.length - 1].body.split('\n')[0].slice(0, 130); }
       else la.classList.add('hidden');
@@ -360,19 +210,19 @@ function loadDetail(number) {
       if (body) c.appendChild(bubble(connectedLogin || 'toi', body, 'user', issue.created_at));
       for (const cm of comments) {
         const isUser = cm.user.type === 'User';
-        const prog = !isUser && /^▶️|^🔎|^📊|^🧠|^⏳|m'en occupe/i.test(cm.body.trim());
-        c.appendChild(bubble(cm.user.login, cm.body, isUser ? 'user' : 'assistant', cm.created_at, prog));
+        c.appendChild(bubble(cm.user.login, cm.body, isUser ? 'user' : 'assistant', cm.created_at, !isUser && isProgress(cm.body)));
       }
-      const needsApproval = comments.some((cm) => /preview|approb|approuv/i.test(cm.body)) && !approved && issue.state === 'open';
+      const needsApproval = comments.some((cm) => /aperçu|preview|approb|approuv/i.test(cm.body)) && !approved && issue.state === 'open';
       $('approve').classList.toggle('hidden', !needsApproval); $('approve').onclick = () => approve(number);
-    } catch (e) { $('detail-msg').className = 'msg err'; $('detail-msg').textContent = friendlyError(e); stopPoll(); }
+    } catch (e) { flash('detail-msg', friendlyError(e), 'err'); stopPoll(); }
   };
   load(); pollTimer = setInterval(load, 6000);
 }
-// ── Mini-rendu Markdown (sensation Claude Desktop) ───────────────────────────
+
+// ── Markdown ────────────────────────────────────────────────────────────────
 function mdLink(u, text) {
   const clean = u.replace(/&amp;/g, '&');
-  if (/\.csv(\?|$)/i.test(clean)) return `<a class="dl" href="${clean}" target="_blank" rel="noopener">📥 Télécharger le CSV</a>`;
+  if (/\.csv(\?|$)/i.test(clean)) return `<a class="dl" href="${clean}" target="_blank" rel="noopener"><svg class="ic"><use href="#i-download"/></svg>Télécharger le CSV</a>`;
   return `<a href="${clean}" target="_blank" rel="noopener">${text || (clean.length > 46 ? clean.slice(0, 43) + '…' : clean)}</a>`;
 }
 function mdInline(s) {
@@ -380,7 +230,7 @@ function mdInline(s) {
   s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
   s = s.replace(/(^|[^*\w])\*([^*\n]+)\*/g, '$1<em>$2</em>');
   s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, (m, t, u) => mdLink(u, t));
-  try { s = s.replace(/(?<!["'>=\/])(https?:\/\/[^\s<]+)/g, (m, u) => mdLink(u, null)); } catch { /* lookbehind non supporté */ }
+  try { s = s.replace(/(?<!["'>=\/])(https?:\/\/[^\s<]+)/g, (m, u) => mdLink(u, null)); } catch {}
   return s;
 }
 function splitRow(l) { return l.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|').map((x) => x.trim()); }
@@ -421,190 +271,255 @@ async function chatSend() {
   ta.value = ''; ta.style.height = 'auto';
   $('comments').appendChild(bubble(connectedLogin || 'toi', txt, 'user', new Date().toISOString()));
   try { await gh(`/issues/${detailNum}/comments`, { method: 'POST', body: JSON.stringify({ body: txt }) }); setTimeout(() => { if (detailNum != null) loadDetail(detailNum); }, 900); }
-  catch (e) { $('detail-msg').className = 'msg err'; $('detail-msg').textContent = friendlyError(e); }
+  catch (e) { flash('detail-msg', friendlyError(e), 'err'); }
 }
 async function approve(number) {
-  const m = $('detail-msg'); m.className = 'msg'; m.textContent = 'Approbation…';
-  try { await gh(`/issues/${number}/labels`, { method: 'POST', body: JSON.stringify({ labels: ['approved'] }) }); m.className = 'msg ok'; m.textContent = 'Approuvé — Claude exécute.'; $('approve').classList.add('hidden'); }
-  catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
+  flash('detail-msg', 'Approbation…');
+  try { await gh(`/issues/${number}/labels`, { method: 'POST', body: JSON.stringify({ labels: ['approved'] }) }); flash('detail-msg', 'Approuvé — Claude exécute.', 'ok'); $('approve').classList.add('hidden'); }
+  catch (e) { flash('detail-msg', friendlyError(e), 'err'); }
 }
 function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
-// ── Système ─────────────────────────────────────────────────────────────────
-function ago(iso) { if (!iso) return '—'; const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 90) return 'à l\'instant'; if (s < 3600) return `il y a ${Math.round(s / 60)} min`; if (s < 86400) return `il y a ${Math.round(s / 3600)} h`; return `il y a ${Math.round(s / 86400)} j`; }
-const SECRET_LABELS = { hubspot: 'HubSpot', lemlist: 'Lemlist', fullenrich: 'FullEnrich', phantombuster: 'PhantomBuster', tavily: 'Tavily', firecrawl: 'Firecrawl', vault: 'Vault', google_sa: 'Google Sheets (SA)' };
-
+// ── Administration : santé & coût ────────────────────────────────────────────
+function ago(iso) { if (!iso) return '—'; const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 90) return "à l'instant"; if (s < 3600) return `il y a ${Math.round(s / 60)} min`; if (s < 86400) return `il y a ${Math.round(s / 3600)} h`; return `il y a ${Math.round(s / 86400)} j`; }
+const SECRET_LABELS = { hubspot: 'HubSpot', fullenrich: 'FullEnrich', phantombuster: 'PhantomBuster', tavily: 'Tavily', firecrawl: 'Firecrawl', vault: 'Vault', google_sa: 'Google Sheets (SA)' };
 async function renderHealthAndCost() {
-  // ── Santé ──
-  const h = await ghJSON('pocket-data/health.json');
-  const ht = $('health-token');
-  if (!h) { ht.className = 'health-token'; ht.textContent = 'Aucune donnée (le canari n\'a pas encore tourné).'; $('health-grid').innerHTML = ''; }
+  const h = await ghJSON('pocket-data/health.json'); const ht = $('health-token');
+  if (!h) { ht.className = 'health-token'; ht.textContent = "Aucune donnée (le canari n'a pas encore tourné)."; $('health-grid').innerHTML = ''; }
   else {
     ht.className = 'health-token ' + (h.token_ok ? 'ok' : 'err');
     ht.innerHTML = h.token_ok
       ? `<svg class="ic"><use href="#i-check"/></svg> Auth Claude OK <small>${escapeHtml(h.model || '')} · vérifié ${ago(h.checked_at)}</small>`
-      : `<svg class="ic"><use href="#i-alert"/></svg> Token Claude expiré — renouvelle-le <small>(vérifié ${ago(h.checked_at)})</small>`;
+      : `<svg class="ic"><use href="#i-alert"/></svg> Token Claude expiré — à renouveler <small>(vérifié ${ago(h.checked_at)})</small>`;
     const sec = h.secrets || {};
     $('health-grid').innerHTML = Object.keys(SECRET_LABELS).map((k) =>
-      `<div class="kcell"><div class="k">${SECRET_LABELS[k]}</div><div class="v sm">${sec[k] ? '<span class="ok-dot">●</span> OK' : '<span class="err-dot">●</span> absent'}</div></div>`
-    ).join('');
+      `<div class="kcell"><div class="k">${SECRET_LABELS[k]}</div><div class="v sm">${sec[k] ? '<span class="ok-dot">●</span> OK' : '<span class="err-dot">●</span> absent'}</div></div>`).join('');
   }
-  // ── Coût réel ──
-  const st = await ghJSON('pocket-data/status.json');
-  const runs = (st && st.runs) || [];
+  const st = await ghJSON('pocket-data/status.json'); const runs = (st && st.runs) || [];
   const now = new Date(), day = now.toISOString().slice(0, 10), month = day.slice(0, 7);
   let cToday = 0, cMonth = 0, nToday = 0;
   for (const r of runs) { const ts = (r.ts || '').slice(0, 10); if (ts === day) { cToday += r.cost_usd || 0; nToday++; } if (ts.slice(0, 7) === month) cMonth += r.cost_usd || 0; }
   const fmt = (n) => '$' + (n || 0).toFixed(2);
   $('cost-box').innerHTML = runs.length
-    ? `<div class="kgrid">${cell('Aujourd\'hui', 'i-clock', fmt(cToday) + ` · ${nToday} run${nToday > 1 ? 's' : ''}`)}${cell('Ce mois', 'i-clock', fmt(cMonth))}${cell('Total suivi', 'i-list', runs.length + ' runs')}</div>`
-    : '<p class="hint" style="margin-top:0">Aucun run enregistré pour l\'instant.</p>';
+    ? `<div class="kgrid">${cell("Aujourd'hui", 'i-clock', fmt(cToday) + ` · ${nToday} run${nToday > 1 ? 's' : ''}`)}${cell('Ce mois', 'i-clock', fmt(cMonth))}${cell('Total suivi', 'i-info', runs.length + ' runs')}</div>`
+    : '<p class="hint" style="margin:0">Aucun run enregistré pour l\'instant.</p>';
 }
 
+// ── Administration : éditeur MCP ─────────────────────────────────────────────
+async function loadMCP() {
+  const data = await ghJSON('pocket-config/mcp.json');
+  mcpServers = Array.isArray(data) ? data : (data && data.servers) || [];
+  renderMCP();
+}
+function renderMCP() {
+  const ul = $('mcp-list'); ul.innerHTML = '';
+  for (const b of MCP_BASE) {
+    const li = document.createElement('li'); li.className = 'mcp-row';
+    li.innerHTML = `<span class="mcp-ic"><svg class="ic"><use href="#i-plug"/></svg></span><span class="mcp-meta"><span class="mcp-n">${b.name}</span><span class="mcp-d">${b.desc}</span></span><span class="mcp-badge base">intégré</span>`;
+    ul.appendChild(li);
+  }
+  for (const s of mcpServers) {
+    const li = document.createElement('li'); li.className = 'mcp-row editable';
+    const d = s.transport === 'http' ? (s.url || '') : ((s.command || '') + ' ' + (s.args || []).join(' '));
+    li.innerHTML = `<span class="mcp-ic"><svg class="ic"><use href="#i-plug"/></svg></span><span class="mcp-meta"><span class="mcp-n">${escapeHtml(s.name)}</span><span class="mcp-d">${escapeHtml(d.trim())}</span></span><span class="mcp-badge ${s.enabled === false ? 'base' : 'on'}">${s.enabled === false ? 'off' : 'actif'}</span>`;
+    li.onclick = () => openMcpEditor(s);
+    ul.appendChild(li);
+  }
+}
+function setTransport(t) {
+  for (const b of document.querySelectorAll('#mcp-transport button')) b.classList.toggle('active', b.dataset.t === t);
+  $('mcp-stdio').classList.toggle('hidden', t !== 'stdio');
+  $('mcp-http').classList.toggle('hidden', t !== 'http');
+}
+function openMcpEditor(s) {
+  editingMcp = s || null;
+  $('mcp-editor').classList.remove('hidden');
+  $('mcp-name').value = s ? s.name : '';
+  setTransport(s && s.transport === 'http' ? 'http' : 'stdio');
+  $('mcp-command').value = s ? (s.command || 'npx') : 'npx';
+  $('mcp-args').value = s && s.args ? s.args.join('\n') : '';
+  $('mcp-url').value = s ? (s.url || '') : '';
+  $('mcp-headers').value = s && s.headers ? Object.entries(s.headers).map(([k, v]) => `${k}: ${v}`).join('\n') : '';
+  $('mcp-env').value = s && s.env ? Object.entries(s.env).map(([k, v]) => `${k}=${v}`).join('\n') : '';
+  $('mcp-tools').value = s && s.allowedTools ? s.allowedTools.join(', ') : '*';
+  $('mcp-delete').classList.toggle('hidden', !s);
+  $('mcp-msg').textContent = '';
+  $('mcp-editor').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+function parsePairs(text, sep) {
+  const o = {}; for (const l of (text || '').split('\n')) { const idx = l.indexOf(sep); if (idx > 0) o[l.slice(0, idx).trim()] = l.slice(idx + 1).trim(); } return o;
+}
+async function saveMcp() {
+  const name = $('mcp-name').value.trim().replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!name) { flash('mcp-msg', 'Nom requis (sans espace).', 'err'); return; }
+  const transport = document.querySelector('#mcp-transport button.active').dataset.t;
+  const tools = $('mcp-tools').value.split(',').map((x) => x.trim()).filter(Boolean);
+  const srv = { name, enabled: true, transport, allowedTools: tools.length ? tools : ['*'] };
+  if (transport === 'http') { srv.url = $('mcp-url').value.trim(); const h = parsePairs($('mcp-headers').value, ':'); if (Object.keys(h).length) srv.headers = h; }
+  else { srv.command = $('mcp-command').value.trim() || 'npx'; srv.args = $('mcp-args').value.split('\n').map((x) => x.trim()).filter(Boolean); }
+  const env = parsePairs($('mcp-env').value, '='); if (Object.keys(env).length) srv.env = env;
+  flash('mcp-msg', 'Enregistrement…');
+  try {
+    const idx = mcpServers.findIndex((x) => x.name === (editingMcp ? editingMcp.name : name));
+    if (idx >= 0) mcpServers[idx] = srv; else mcpServers.push(srv);
+    await putJSON('pocket-config/mcp.json', mcpServers, 'pocket: MCP ' + name);
+    flash('mcp-msg', 'Serveur enregistré — actif à la prochaine tâche.', 'ok');
+    $('mcp-editor').classList.add('hidden'); renderMCP();
+  } catch (e) { flash('mcp-msg', friendlyError(e), 'err'); }
+}
+async function deleteMcp() {
+  if (!editingMcp) return; flash('mcp-msg', 'Suppression…');
+  try {
+    mcpServers = mcpServers.filter((x) => x.name !== editingMcp.name);
+    await putJSON('pocket-config/mcp.json', mcpServers, 'pocket: remove MCP ' + editingMcp.name);
+    $('mcp-editor').classList.add('hidden'); renderMCP(); flash('mcp-msg', '', '');
+  } catch (e) { flash('mcp-msg', friendlyError(e), 'err'); }
+}
+
+// ── Connaissances ────────────────────────────────────────────────────────────
+let knowSha = {};
+async function loadKnowledge() {
+  const d = $('know-domain').value; $('know-msg').textContent = ''; $('know-text').value = 'Chargement…';
+  try { const c = await gh('/contents/pocket-knowledge/' + d + '.md'); $('know-text').value = decodeB64(c.content); knowSha[d] = c.sha; }
+  catch { $('know-text').value = ''; knowSha[d] = null; }
+}
+async function saveKnowledge() {
+  const d = $('know-domain').value; flash('know-msg', 'Enregistrement…');
+  try {
+    const body = { message: 'knowledge: ' + d + ' (édition manuelle)', content: b64($('know-text').value) };
+    if (knowSha[d]) body.sha = knowSha[d];
+    const r = await gh('/contents/pocket-knowledge/' + d + '.md', { method: 'PUT', body: JSON.stringify(body) });
+    knowSha[d] = r.content.sha; flash('know-msg', 'Enregistré.', 'ok');
+  } catch (e) { flash('know-msg', friendlyError(e), 'err'); }
+}
+
+// ── Système (device) ─────────────────────────────────────────────────────────
 async function renderSystem() {
-  renderHealthAndCost();
   const d = [];
   d.push(cell('CPU (cœurs)', 'i-cpu', navigator.hardwareConcurrency || '—'));
   d.push(cell('Mémoire', 'i-cpu', navigator.deviceMemory ? navigator.deviceMemory + ' Go' : 'non exposé'));
   d.push(cell('Plateforme', 'i-info', escapeHtml(navigator.platform || '—')));
-  d.push(cell('Écran', 'i-info', `${screen.width}×${screen.height}`));
   d.push(cell('Réseau', 'i-info', (navigator.connection && navigator.connection.effectiveType) || 'non exposé'));
-  let bat = 'non exposé (iOS)'; if (navigator.getBattery) { try { const b = await navigator.getBattery(); bat = Math.round(b.level * 100) + '%' + (b.charging ? ' ⚡' : ''); } catch {} }
+  let bat = 'non exposé'; if (navigator.getBattery) { try { const b = await navigator.getBattery(); bat = Math.round(b.level * 100) + '%' + (b.charging ? ' (charge)' : ''); } catch {} }
   d.push(cell('Batterie', 'i-info', bat));
+  d.push(cell('Version', 'i-info', APP_VERSION));
   $('system-grid').innerHTML = d.join('');
-  $('claude-grid').innerHTML = [cell('Modèle', 'i-brain', MODEL), cell('Version app', 'i-info', APP_VERSION), cell('Exécution', 'i-robot', 'GitHub Actions'), cell('Contexte', 'i-brain', '~200K, neuf/tâche')].join('');
-  // Usage estimé sur la fenêtre 5h (à partir des tâches récentes)
-  const now = Date.now(), WIN = 5 * 3600 * 1000;
-  const recent = (allIssues || []).filter((i) => i.created_at && now - new Date(i.created_at) < WIN);
-  let tok = 0;
-  for (const i of recent) tok += estTokens(i.body) + (i.comments || 0) * 250;
-  const REF = 1000000; // référence indicative pour une session 5h chargée
-  const pct = Math.min(100, tok / REF * 100);
-  $('usage-box').innerHTML =
-    `<div class="kgrid">${cell('Tâches (5h)', 'i-list', recent.length)}${cell('Tokens estim. (5h)', 'i-brain', '≈ ' + tok.toLocaleString('fr-FR'))}</div>` +
-    `<div class="kcell wide" style="margin-top:8px"><div class="k"><svg class="ic"><use href="#i-clock"/></svg>Fenêtre 5h (indicatif /1M)</div><div class="gauge ${pct > 80 ? 'warn' : ''}"><i style="width:${pct}%"></i></div></div>`;
 }
 
-// ── Push ────────────────────────────────────────────────────────────────────
+// ── Push ─────────────────────────────────────────────────────────────────────
 function urlB64ToUint8Array(s) { const p = '='.repeat((4 - s.length % 4) % 4); const b = (s + p).replace(/-/g, '+').replace(/_/g, '/'); const r = atob(b); const a = new Uint8Array(r.length); for (let i = 0; i < r.length; i++) a[i] = r.charCodeAt(i); return a; }
 async function enablePush() {
-  const m = $('push-msg'); m.className = 'msg';
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) { m.className = 'msg err'; m.textContent = 'Push indisponible. Ouvre l\'app depuis l\'écran d\'accueil (iOS 16.4+).'; return; }
-  m.textContent = 'Autorisation…';
+  flash('push-msg', 'Autorisation…');
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) { flash('push-msg', "Push indisponible. Ouvre l'app depuis l'écran d'accueil (iOS 16.4+).", 'err'); return; }
   try {
-    if (await Notification.requestPermission() !== 'granted') { m.className = 'msg err'; m.textContent = 'Permission refusée.'; return; }
+    if (await Notification.requestPermission() !== 'granted') { flash('push-msg', 'Permission refusée.', 'err'); return; }
     const reg = await navigator.serviceWorker.ready;
     let sub = await reg.pushManager.getSubscription();
     if (!sub) sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlB64ToUint8Array(VAPID_PUBLIC) });
-    await putFile(`pocket-data/sub-${LS.device}.json`, sub.toJSON());
-    m.className = 'msg ok'; m.textContent = '✅ Notifications activées.';
-  } catch (e) { m.className = 'msg err'; m.textContent = 'Échec : ' + (e.message || e); }
+    await putJSON(`pocket-data/sub-${LS.device}.json`, sub.toJSON(), 'pocket: sub ' + LS.device);
+    flash('push-msg', 'Notifications activées.', 'ok');
+  } catch (e) { flash('push-msg', 'Échec : ' + (e.message || e), 'err'); }
 }
 
-// ── Router ──────────────────────────────────────────────────────────────────
+// ── Router ────────────────────────────────────────────────────────────────────
 function applyView(view) {
   const isDetail = view.startsWith('detail:');
   currentView = isDetail ? 'detail' : view;
+  $('home').classList.toggle('hidden', !(view === 'home' || view === 'main'));
   $('detail').classList.toggle('hidden', !isDetail);
-  $('system').classList.toggle('hidden', view !== 'system');
-  $('modes').classList.toggle('hidden', view !== 'modes');
-  $('knowledge').classList.toggle('hidden', view !== 'knowledge');
-  const isMain = !isDetail && !['system', 'modes', 'knowledge'].includes(view);
-  for (const id of ['dashboard', 'composer', 'history']) $(id).classList.toggle('hidden', !isMain);
+  $('admin').classList.toggle('hidden', view !== 'admin');
   if (!isDetail) stopPoll();
   stopMainPoll();
-  if (view === 'system') renderSystem();
-  else if (view === 'modes') { renderModes(); $('mode-editor').classList.add('hidden'); }
-  else if (view === 'knowledge') loadKnowledge();
-  else if (isDetail) loadDetail(parseInt(view.split(':')[1], 10));
-  else { detailNum = null; loadHistory(); startMainPoll(); }
+  if (isDetail) loadDetail(parseInt(view.split(':')[1], 10));
+  else if (view === 'admin') { renderHealthAndCost(); loadMCP(); renderSystem(); $('mcp-editor').classList.add('hidden'); }
+  else { detailNum = null; if (LS.repo && LS.pat) { loadHistory(); startMainPoll(); } }
   window.scrollTo(0, 0);
 }
-function startMainPoll() { stopMainPoll(); mainTimer = setInterval(() => { if (LS.repo && LS.pat && !document.hidden) loadHistory(); }, 20000); }
+function startMainPoll() { stopMainPoll(); mainTimer = setInterval(() => { if (LS.repo && LS.pat && !document.hidden && currentView === 'home') loadHistory(); }, 20000); }
 function stopMainPoll() { if (mainTimer) { clearInterval(mainTimer); mainTimer = null; } }
 function navigate(view) { history.pushState({ view }, '', '#' + view); applyView(view); }
 
-function escapeHtml(s) { return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])); }
-function timeago(iso) { const s = Math.max(0, (Date.now() - new Date(iso)) / 1000); if (s < 60) return 'à l\'instant'; if (s < 3600) return `il y a ${Math.floor(s / 60)} min`; if (s < 86400) return `il y a ${Math.floor(s / 3600)} h`; return `il y a ${Math.floor(s / 86400)} j`; }
 async function testConn(silent) {
   const dot = $('conn-dot');
   try { const r = await gh(''); dot.className = 'dot ok'; try { const u = await (await fetch('https://api.github.com/user', { headers: { Authorization: `Bearer ${LS.pat}`, Accept: 'application/vnd.github+json' } })).json(); if (u && u.login) connectedLogin = u.login; } catch {} return r; }
   catch { dot.className = 'dot err'; if (!silent) throw new Error('non connecté'); return null; }
 }
-
 function setupMic() {
   const SR = window.SpeechRecognition || window.webkitSpeechRecognition; const mic = $('mic');
-  $('mic-hint').classList.remove('hidden'); // l'astuce clavier reste toujours dispo
   if (!SR) { mic.style.display = 'none'; return; }
   const rec = new SR(); rec.lang = 'fr-FR'; rec.interimResults = true; rec.continuous = true; let base = '', live = false;
   rec.onresult = (e) => { let t = ''; for (let i = e.resultIndex; i < e.results.length; i++) t += e.results[i][0].transcript; $('demande').value = (base + ' ' + t).trim(); };
-  rec.onerror = (e) => { live = false; mic.classList.remove('live'); if (e && e.error === 'not-allowed') { const m = $('composer-msg'); m.className = 'msg err'; m.textContent = 'Micro refusé. Utilise le micro du clavier iOS (astuce ci-dessus).'; } };
+  rec.onerror = (e) => { live = false; mic.classList.remove('live'); if (e && e.error === 'not-allowed') flash('composer-msg', 'Micro refusé. Utilise le micro du clavier iOS.', 'err'); };
   rec.onend = () => { live = false; mic.classList.remove('live'); };
   mic.onclick = () => { if (live) { rec.stop(); return; } base = $('demande').value; try { rec.start(); live = true; mic.classList.add('live'); } catch { mic.classList.remove('live'); } };
 }
-
-// ── Thème ───────────────────────────────────────────────────────────────────
 function applyTheme(t) {
   if (t === 'auto') document.documentElement.removeAttribute('data-theme');
   else document.documentElement.setAttribute('data-theme', t);
   for (const b of document.querySelectorAll('#theme-seg button')) b.classList.toggle('active', b.dataset.theme === t);
-  const meta = document.querySelector('meta[name=theme-color]'); if (meta) meta.setAttribute('content', t === 'light' ? '#eef1f7' : '#0a0e16');
+  const meta = document.querySelector('meta[name=theme-color]'); if (meta) meta.setAttribute('content', t === 'light' ? '#f4efe6' : '#1b1815');
 }
+function setModel(m) { selectedModel = m; LS.model = m; for (const b of document.querySelectorAll('#model-seg button')) b.classList.toggle('active', b.dataset.model === m); }
 
 function init() {
   $('repo').value = LS.repo || 'GaspardCoche/agent-system'; $('pat').value = LS.pat;
-  if (!LS.repo || !LS.pat) $('settings').classList.remove('hidden');
-  $('brand-home').onclick = () => navigate('main');
-  $('nav-settings').onclick = () => $('settings').classList.toggle('hidden');
-  $('nav-system').onclick = () => navigate('system');
-  $('health-refresh').onclick = async () => {
-    const m = $('health-msg'); m.className = 'msg'; m.textContent = 'Test lancé…';
-    try {
-      await gh('/actions/workflows/pocket-health.yml/dispatches', { method: 'POST', body: JSON.stringify({ ref: 'main' }) });
-      m.className = 'msg ok'; m.textContent = 'Canari lancé — résultat dans ~40 s.';
-      setTimeout(() => { renderHealthAndCost(); m.textContent = ''; }, 45000);
-    } catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-  };
-  $('nav-modes').onclick = () => navigate('modes');
-  $('modes-back').onclick = () => history.back();
-  $('mode-new').onclick = () => openModeEditor(null);
-  $('mode-save').onclick = saveMode;
-  $('mode-delete').onclick = deleteMode;
-  $('mode-freq').onchange = (e) => { $('sched-extra').classList.toggle('hidden', e.target.value === 'none'); $('weekday-wrap').classList.toggle('hidden', e.target.value !== 'weekly'); };
-  $('open-knowledge').onclick = () => navigate('knowledge');
-  $('knowledge-back').onclick = () => history.back();
-  for (const b of document.querySelectorAll('#source-filter button')) b.onclick = () => { currentSource = b.dataset.src; currentFilter = 'all'; renderSourceFilter(); renderFilters(); renderHistory(); renderDashboard(); };
-  $('refresh-btn').onclick = () => { if (LS.repo && LS.pat) loadHistory(); };
-  document.addEventListener('visibilitychange', () => { if (!document.hidden && currentView === 'main' && LS.repo && LS.pat) loadHistory(); });
-  $('know-domain').onchange = loadKnowledge;
-  $('know-save').onclick = saveKnowledge;
-  $('system-back').onclick = () => history.back();
+  // greeting
+  const hr = new Date().getHours();
+  $('greet').textContent = hr < 6 ? 'Bonne nuit.' : hr < 18 ? 'Bonjour.' : 'Bonsoir.';
+  // nav
+  $('brand-home').onclick = () => navigate('home');
+  $('nav-new').onclick = () => { navigate('home'); $('demande').focus(); };
+  $('nav-admin').onclick = () => navigate('admin');
   $('back').onclick = () => history.back();
-  $('save-settings').onclick = async () => {
-    LS.repo = $('repo').value.trim(); LS.pat = $('pat').value.trim();
-    const m = $('settings-msg'); m.className = 'msg'; m.textContent = 'Test…';
-    try { const r = await testConn(false); m.className = 'msg ok'; m.textContent = `Connecté à ${r.full_name}${connectedLogin ? ' · ' + connectedLogin : ''}`; loadHistory(); loadModes(); setTimeout(() => $('settings').classList.add('hidden'), 1400); }
-    catch (e) { m.className = 'msg err'; m.textContent = friendlyError(e); }
-  };
-  $('enable-push').onclick = enablePush;
-  // Thème
-  applyTheme(LS.theme);
-  for (const b of document.querySelectorAll('#theme-seg button')) b.onclick = () => { LS.theme = b.dataset.theme; applyTheme(b.dataset.theme); };
-  // Import de fichiers
+  $('admin-back').onclick = () => history.back();
+  // model picker
+  setModel(LS.model);
+  for (const b of document.querySelectorAll('#model-seg button')) b.onclick = () => setModel(b.dataset.model);
+  // composer
+  $('dispatch').onclick = dispatch;
+  $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
+  for (const ch of document.querySelectorAll('#quick-chips .chip')) ch.onclick = () => { $('demande').value = ch.dataset.q; $('demande').focus(); };
+  // files + drag/drop
   $('attach-btn').onclick = () => $('file-input').click();
   $('file-input').onchange = (e) => { addFiles(e.target.files); e.target.value = ''; };
-  $('write-allowed').onchange = (e) => $('conditions-wrap').classList.toggle('hidden', !e.target.checked);
-  $('dispatch').onclick = dispatch;
-  for (const ch of document.querySelectorAll('#chips .chip')) ch.onclick = () => { $('demande').value = ch.dataset.q; $('demande').focus(); };
+  const dz = $('dropzone');
+  ['dragover', 'dragenter'].forEach((ev) => dz.addEventListener(ev, (e) => { e.preventDefault(); dz.classList.add('drag'); }));
+  ['dragleave', 'drop'].forEach((ev) => dz.addEventListener(ev, (e) => { e.preventDefault(); dz.classList.remove('drag'); }));
+  dz.addEventListener('drop', (e) => { if (e.dataTransfer && e.dataTransfer.files) addFiles(e.dataTransfer.files); });
+  // detail chat
   $('chat-send').onclick = chatSend;
-  $('chat-input').addEventListener('input', (e) => { e.target.style.height = 'auto'; e.target.style.height = Math.min(e.target.scrollHeight, 140) + 'px'; });
-  window.addEventListener('popstate', (e) => applyView((e.state && e.state.view) || 'main'));
-
+  $('chat-input').addEventListener('input', (e) => { e.target.style.height = 'auto'; e.target.style.height = Math.min(e.target.scrollHeight, 130) + 'px'; });
+  // admin: settings
+  $('save-settings').onclick = async () => {
+    LS.repo = $('repo').value.trim(); LS.pat = $('pat').value.trim();
+    flash('settings-msg', 'Test…');
+    try { const r = await testConn(false); flash('settings-msg', `Connecté à ${r.full_name}${connectedLogin ? ' · ' + connectedLogin : ''}`, 'ok'); loadHistory(); renderHealthAndCost(); loadMCP(); }
+    catch (e) { flash('settings-msg', friendlyError(e), 'err'); }
+  };
+  $('health-refresh').onclick = async () => {
+    flash('health-msg', 'Test lancé…');
+    try { await gh('/actions/workflows/pocket-health.yml/dispatches', { method: 'POST', body: JSON.stringify({ ref: 'main' }) }); flash('health-msg', 'Canari lancé — résultat dans ~40 s.', 'ok'); setTimeout(() => { renderHealthAndCost(); flash('health-msg', '', ''); }, 45000); }
+    catch (e) { flash('health-msg', friendlyError(e), 'err'); }
+  };
+  // admin: MCP editor
+  $('mcp-new').onclick = () => openMcpEditor(null);
+  for (const b of document.querySelectorAll('#mcp-transport button')) b.onclick = () => setTransport(b.dataset.t);
+  $('mcp-save').onclick = saveMcp;
+  $('mcp-delete').onclick = deleteMcp;
+  // admin: knowledge
+  $('know-domain').onchange = loadKnowledge;
+  $('know-save').onclick = saveKnowledge;
+  // admin: theme + push
+  applyTheme(LS.theme);
+  for (const b of document.querySelectorAll('#theme-seg button')) b.onclick = () => { LS.theme = b.dataset.theme; applyTheme(b.dataset.theme); };
+  $('enable-push').onclick = enablePush;
+  // misc
+  document.addEventListener('visibilitychange', () => { if (!document.hidden && currentView === 'home' && LS.repo && LS.pat) loadHistory(); });
+  window.addEventListener('popstate', (e) => applyView((e.state && e.state.view) || 'home'));
   const vb = $('ver-badge'); if (vb) vb.textContent = APP_VERSION;
-
   setupMic();
-  history.replaceState({ view: 'main' }, '', '#main');
-  if (LS.repo && LS.pat) { testConn(true).then(() => { loadHistory(); loadModes(); startMainPoll(); }); } else { renderHistory(); }
+  history.replaceState({ view: 'home' }, '', '#home');
+  if (LS.repo && LS.pat) { testConn(true).then(() => { loadHistory(); startMainPoll(); }); } else { renderHistory(); navigate('admin'); }
   if ('serviceWorker' in navigator) {
     let refreshing = false;
     navigator.serviceWorker.addEventListener('controllerchange', () => { if (refreshing) return; refreshing = true; location.reload(); });

--- a/docs/pocket/icon.svg
+++ b/docs/pocket/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" rx="112" fill="#0b0f17"/>
-  <circle cx="256" cy="256" r="150" fill="none" stroke="#6aa3ff" stroke-width="26"/>
-  <path d="M316 196a86 86 0 1 0 0 120" fill="none" stroke="#6aa3ff" stroke-width="26" stroke-linecap="round"/>
-  <circle cx="256" cy="256" r="26" fill="#6aa3ff"/>
+  <rect width="512" height="512" rx="112" fill="#1b1815"/>
+  <circle cx="256" cy="256" r="150" fill="none" stroke="#d97757" stroke-width="26"/>
+  <path d="M316 196a86 86 0 1 0 0 120" fill="none" stroke="#d97757" stroke-width="26" stroke-linecap="round"/>
+  <circle cx="256" cy="256" r="26" fill="#d97757"/>
 </svg>

--- a/docs/pocket/index.html
+++ b/docs/pocket/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
-  <meta name="theme-color" content="#0a0e16" />
+  <meta name="theme-color" content="#1c1917" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Pocket" />
@@ -14,214 +14,209 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <!-- ── Sprite d'icônes (SVG, remplace les emojis) ── -->
+  <!-- ── Sprite d'icônes (SVG uniquement — aucun emoji) ── -->
   <svg width="0" height="0" style="position:absolute" aria-hidden="true">
     <defs>
-      <symbol id="i-gear" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.6 1.6 0 00.3 1.8l.1.1a2 2 0 11-2.8 2.8l-.1-.1a1.6 1.6 0 00-2.7.6 1.6 1.6 0 00-1 1.5V22a2 2 0 11-4 0v-.1A1.6 1.6 0 008 20.3a1.6 1.6 0 00-1.8.3l-.1.1a2 2 0 11-2.8-2.8l.1-.1a1.6 1.6 0 00-.6-2.7 1.6 1.6 0 00-1.5-1H2a2 2 0 110-4h.1A1.6 1.6 0 003.7 8a1.6 1.6 0 00-.3-1.8l-.1-.1a2 2 0 112.8-2.8l.1.1a1.6 1.6 0 002.7-.6h.1A1.6 1.6 0 0010 .1V0a2 2 0 114 0v.1a1.6 1.6 0 001 1.5 1.6 1.6 0 001.8-.3l.1-.1a2 2 0 112.8 2.8l-.1.1a1.6 1.6 0 00-.3 2.7v.1a1.6 1.6 0 001.5 1H22a2 2 0 110 4h-.1a1.6 1.6 0 00-1.5 1z" transform="scale(.85) translate(2 2)"/></symbol>
+      <symbol id="i-gear" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.7"/><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M12 2v2.2M12 19.8V22M4.9 4.9l1.6 1.6M17.5 17.5l1.6 1.6M2 12h2.2M19.8 12H22M4.9 19.1l1.6-1.6M17.5 6.5l1.6-1.6"/></symbol>
       <symbol id="i-send" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"/></symbol>
-      <symbol id="i-mic" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M19 10v2a7 7 0 01-14 0v-2M12 19v4"/></symbol>
+      <symbol id="i-mic" viewBox="0 0 24 24"><rect x="9" y="1.5" width="6" height="12" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M19 10v2a7 7 0 01-14 0v-2M12 19v3"/></symbol>
       <symbol id="i-check" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="M20 6L9 17l-5-5"/></symbol>
-      <symbol id="i-alert" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 9v4M12 17h.01M10.3 3.9L1.8 18a2 2 0 001.7 3h17a2 2 0 001.7-3L14.7 3.9a2 2 0 00-3.4 0z"/></symbol>
+      <symbol id="i-alert" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 8v5M12 17h.01M10.3 3.2L1.7 18a2 2 0 001.7 3h17.2a2 2 0 001.7-3L13.7 3.2a2 2 0 00-3.4 0z"/></symbol>
       <symbol id="i-back" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M19 12H5M12 19l-7-7 7-7"/></symbol>
-      <symbol id="i-cpu" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><rect x="9" y="9" width="6" height="6" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 14h3M1 9h3M1 14h3"/></symbol>
-      <symbol id="i-brain" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M9.5 2A2.5 2.5 0 007 4.5v.5a3 3 0 00-2 5.6V13a3 3 0 002 5.6V19a2.5 2.5 0 005 0V4.5A2.5 2.5 0 009.5 2zM14.5 2A2.5 2.5 0 0117 4.5v.5a3 3 0 012 5.6V13a3 3 0 01-2 5.6V19a2.5 2.5 0 01-5 0"/></symbol>
+      <symbol id="i-spark" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9L12 3zM19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15z"/></symbol>
       <symbol id="i-bell" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M18 8a6 6 0 00-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 01-3.4 0"/></symbol>
-      <symbol id="i-robot" viewBox="0 0 24 24"><rect x="3" y="8" width="18" height="12" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M12 8V4M8 2h8"/><circle cx="8.5" cy="14" r="1.4" fill="currentColor"/><circle cx="15.5" cy="14" r="1.4" fill="currentColor"/></symbol>
+      <symbol id="i-plug" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" d="M9 2v6M15 2v6M7 8h10v3a5 5 0 01-10 0V8zM12 16v6"/></symbol>
       <symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M12 7v5l3 2"/></symbol>
       <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 16v-4M12 8h.01"/></symbol>
-      <symbol id="i-list" viewBox="0 0 24 24"><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></symbol>
       <symbol id="i-plus" viewBox="0 0 24 24"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M12 5v14M5 12h14"/></symbol>
-      <symbol id="i-clip" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M21.4 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.2-9.19a4 4 0 015.65 5.66l-9.2 9.19a2 2 0 01-2.82-2.83l8.48-8.48"/></symbol>
+      <symbol id="i-clip" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M21.4 11l-9.2 9.2a6 6 0 01-8.5-8.5l9.2-9.2a4 4 0 015.7 5.7l-9.2 9.2a2 2 0 01-2.9-2.9l8.5-8.5"/></symbol>
+      <symbol id="i-download" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 3v12M7 10l5 5 5-5M4 20h16"/></symbol>
+      <symbol id="i-trash" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M9 6V4h6v2M6 6l1 14h10l1-14"/></symbol>
       <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.8"/><path stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4"/></symbol>
+      <symbol id="i-cpu" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><rect x="9" y="9" width="6" height="6" fill="none" stroke="currentColor" stroke-width="1.7"/><path stroke="currentColor" stroke-width="1.7" stroke-linecap="round" d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 14h3M1 9h3M1 14h3"/></symbol>
+      <symbol id="i-brain" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M9.5 2A2.5 2.5 0 007 4.5v.5a3 3 0 00-2 5.6V13a3 3 0 002 5.6V19a2.5 2.5 0 005 0V4.5A2.5 2.5 0 009.5 2zM14.5 2A2.5 2.5 0 0117 4.5v.5a3 3 0 012 5.6V13a3 3 0 01-2 5.6V19a2.5 2.5 0 01-5 0"/></symbol>
+      <symbol id="i-chevron" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M9 18l6-6-6-6"/></symbol>
     </defs>
   </svg>
 
-  <header>
-    <button class="brand" id="brand-home"><img src="icon.svg" class="logo" alt="Pocket" /> Claude Pocket <span class="dot" id="conn-dot"></span><span id="ver-badge" class="ver">v15</span></button>
+  <header id="topbar">
+    <button class="brand" id="brand-home">
+      <img src="icon.svg" class="logo" alt="" />
+      <span class="wordmark">Pocket</span>
+      <span class="dot" id="conn-dot"></span>
+    </button>
     <div class="hbtns">
-      <button class="icon-btn" id="nav-modes" title="Modes agentiques"><svg class="ic"><use href="#i-robot"/></svg></button>
-      <button class="icon-btn" id="nav-system" title="Système"><svg class="ic"><use href="#i-cpu"/></svg></button>
-      <button class="icon-btn" id="nav-settings" title="Réglages"><svg class="ic"><use href="#i-gear"/></svg></button>
+      <button class="icon-btn" id="nav-new" title="Nouvelle conversation"><svg class="ic"><use href="#i-plus"/></svg></button>
+      <button class="icon-btn" id="nav-admin" title="Administration"><svg class="ic"><use href="#i-gear"/></svg></button>
     </div>
   </header>
 
-  <!-- ── Réglages ── -->
-  <section id="settings" class="card hidden">
-    <h2><svg class="ic"><use href="#i-gear"/></svg> Réglages</h2>
-    <label>Repo <small>(owner/nom)</small>
-      <input id="repo" type="text" placeholder="GaspardCoche/agent-system" autocapitalize="off" autocorrect="off" spellcheck="false" />
-    </label>
-    <label>GitHub token <small>(classic, scope repo)</small>
-      <input id="pat" type="password" placeholder="ghp_…" autocapitalize="off" autocorrect="off" spellcheck="false" />
-    </label>
-    <button id="save-settings" class="primary">Enregistrer &amp; tester</button>
-    <p id="settings-msg" class="msg"></p>
-    <label style="margin-top:14px">Thème
-      <div class="seg" id="theme-seg">
-        <button data-theme="auto">Auto</button>
-        <button data-theme="light"><svg class="ic"><use href="#i-sun"/></svg> Clair</button>
-        <button data-theme="dark">Sombre</button>
+  <main>
+    <!-- ══ ACCUEIL — chat-first ══ -->
+    <section id="home" class="view">
+      <div class="hero">
+        <h1 class="greet" id="greet">Bonjour.</h1>
+        <p class="sub">Décris ta tâche — je m'occupe du CRM, de l'enrichissement, de la recherche et de la rédaction.</p>
       </div>
-    </label>
-    <button id="enable-push" class="ghost"><svg class="ic"><use href="#i-bell"/></svg> Activer les notifications</button>
-    <p id="push-msg" class="msg"></p>
-  </section>
 
-  <!-- ── Système / monitoring device ── -->
-  <section id="system" class="card hidden">
-    <button class="link-btn" id="system-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
-    <h2><svg class="ic"><use href="#i-check"/></svg> Santé des systèmes</h2>
-    <div id="health-token" class="health-token">Chargement…</div>
-    <div id="health-grid" class="kgrid"></div>
-    <button id="health-refresh" class="ghost" style="margin-top:8px"><svg class="ic"><use href="#i-clock"/></svg> Tester maintenant</button>
-    <p id="health-msg" class="msg"></p>
-    <h2 style="margin-top:18px"><svg class="ic"><use href="#i-clock"/></svg> Coût réel</h2>
-    <div id="cost-box"></div>
-    <h2 style="margin-top:18px"><svg class="ic"><use href="#i-cpu"/></svg> Système</h2>
-    <div id="system-grid" class="kgrid"></div>
-    <h2 style="margin-top:18px"><svg class="ic"><use href="#i-brain"/></svg> Claude</h2>
-    <div id="claude-grid" class="kgrid"></div>
-    <h2 style="margin-top:18px"><svg class="ic"><use href="#i-clock"/></svg> Usage (estimation)</h2>
-    <div id="usage-box"></div>
-    <p class="hint">Estimation (longueur des échanges ÷ 4 ≈ tokens). Le quota réel des sessions 5h d'Anthropic n'est pas exposé par l'API ; ces valeurs servent d'ordre de grandeur. Claude tourne sur GitHub Actions (cloud) — le CPU/GPU du runner n'est pas exposé.</p>
-  </section>
+      <section class="composer">
+        <div class="ta-wrap">
+          <textarea id="demande" rows="3" placeholder="Écris ou dicte ta demande…"></textarea>
+          <button id="mic" class="icon-btn mic" title="Dicter"><svg class="ic"><use href="#i-mic"/></svg></button>
+        </div>
 
-  <!-- ── Modes agentiques ── -->
-  <section id="modes" class="card hidden">
-    <button class="link-btn" id="modes-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
-    <h2><svg class="ic"><use href="#i-robot"/></svg> Modes agentiques</h2>
-    <p class="hint" style="margin-top:0">Crée tes propres agents : un nom, une catégorie et des instructions. Ils deviennent sélectionnables au lancement d'une tâche.</p>
-    <button id="open-knowledge" class="ghost" style="margin-top:8px"><svg class="ic"><use href="#i-brain"/></svg> Connaissances accumulées</button>
-    <button id="mode-new" class="primary" style="margin:12px 0"><svg class="ic"><use href="#i-plus"/></svg> Nouveau mode</button>
-    <ul id="modes-list"></ul>
-    <div id="mode-editor" class="hidden" style="margin-top:14px;border-top:1px solid var(--line);padding-top:14px">
-      <label>Nom <input id="mode-name" type="text" placeholder="Ex : Veille concurrent" /></label>
-      <label>Catégorie
-        <select id="mode-cat">
-          <option value="cat:crm">CRM</option>
-          <option value="cat:web">Web</option>
-          <option value="cat:enrich">Enrichissement</option>
-          <option value="cat:outreach">Outreach</option>
-          <option value="cat:vault">Vault</option>
-          <option value="cat:code">Code</option>
-          <option value="cat:other">Autre</option>
-        </select>
-      </label>
-      <label>Description <input id="mode-desc" type="text" placeholder="À quoi sert cet agent" /></label>
-      <label><svg class="ic"><use href="#i-robot"/></svg> Enchaîner vers (chaîne d'automatisation)
-        <select id="mode-chain"><option value="">Aucun</option></select>
-      </label>
-      <label>Instructions (le « cerveau » de l'agent)
-        <textarea id="mode-instr" rows="6" placeholder="Tu es un agent qui… Décris précisément sa mission, ses étapes, ses limites."></textarea>
-      </label>
-      <label><svg class="ic"><use href="#i-clock"/></svg> Déclenchement programmé
-        <select id="mode-freq">
-          <option value="none">Aucun (lancement manuel)</option>
-          <option value="daily">Tous les jours</option>
-          <option value="weekly">Chaque semaine</option>
-        </select>
-      </label>
-      <div id="sched-extra" class="hidden">
-        <label>Heure <input id="mode-time" type="time" value="08:00" /></label>
-        <label id="weekday-wrap" class="hidden">Jour
-          <select id="mode-weekday">
-            <option value="0">Lundi</option><option value="1">Mardi</option><option value="2">Mercredi</option>
-            <option value="3">Jeudi</option><option value="4">Vendredi</option><option value="5">Samedi</option><option value="6">Dimanche</option>
+        <div id="dropzone" class="dropzone">
+          <input id="file-input" type="file" multiple hidden />
+          <button id="attach-btn" class="chip ghost-chip"><svg class="ic"><use href="#i-clip"/></svg> Joindre un fichier</button>
+          <span class="drop-hint">ou glisse-dépose ici</span>
+        </div>
+        <div id="file-list" class="file-list"></div>
+
+        <div class="model-row">
+          <span class="model-label">Modèle</span>
+          <div class="seg" id="model-seg">
+            <button data-model="fable">Fable</button>
+            <button data-model="opus" class="active">Opus 4.8</button>
+            <button data-model="sonnet">Sonnet</button>
+          </div>
+        </div>
+
+        <div class="write-row">
+          <label class="toggle"><input id="write-allowed" type="checkbox" /><span class="track"></span> Autoriser l'écriture (CRM / enrichissement)</label>
+        </div>
+        <div id="conditions-wrap" class="hidden">
+          <textarea id="conditions" rows="2" placeholder="Conditions d'écriture — ex : mets lifecyclestage à « lead », ne jamais écraser une valeur."></textarea>
+        </div>
+
+        <button id="dispatch" class="primary big"><svg class="ic"><use href="#i-send"/></svg> Envoyer</button>
+        <p id="composer-msg" class="msg"></p>
+
+        <div class="chips" id="quick-chips">
+          <button class="chip" data-q="Combien de contacts par lifecyclestage dans HubSpot ?">Stats CRM</button>
+          <button class="chip" data-q="Rédige un email de relance court et percutant pour un DAF de PME.">Rédiger un email</button>
+          <button class="chip" data-q="Prends la liste HubSpot « … » et enrichis les contacts manquants via FullEnrich.">Enrichir une liste</button>
+        </div>
+      </section>
+
+      <section class="recent">
+        <div class="recent-head">
+          <h2>Conversations</h2>
+          <div class="mini-stats" id="mini-stats"></div>
+        </div>
+        <ul id="history-list" class="thread-list"></ul>
+      </section>
+    </section>
+
+    <!-- ══ CONVERSATION ══ -->
+    <section id="detail" class="view hidden">
+      <div class="detail-top">
+        <button class="link-btn" id="back"><svg class="ic"><use href="#i-back"/></svg> Conversations</button>
+        <div id="run-status" class="status-pill idle">Chargement…</div>
+      </div>
+      <h2 id="detail-title" class="conv-title">Conversation</h2>
+      <div id="live-activity" class="live-activity hidden"></div>
+      <div id="comments" class="chat"></div>
+      <button id="approve" class="primary hidden"><svg class="ic"><use href="#i-check"/></svg> Approuver l'écriture</button>
+      <details id="monitor-wrap" class="monitor-wrap">
+        <summary>Détails d'exécution</summary>
+        <div id="monitor" class="monitor"></div>
+        <a id="run-link" class="run-link hidden" target="_blank" rel="noopener">Logs bruts ↗</a>
+      </details>
+      <p id="detail-msg" class="msg"></p>
+      <div class="chatbar">
+        <textarea id="chat-input" rows="1" placeholder="Réponds ou affine…"></textarea>
+        <button id="chat-send" class="icon-btn send" title="Envoyer"><svg class="ic"><use href="#i-send"/></svg></button>
+      </div>
+    </section>
+
+    <!-- ══ ADMINISTRATION ══ -->
+    <section id="admin" class="view hidden">
+      <button class="link-btn" id="admin-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
+      <h1 class="admin-title">Administration</h1>
+
+      <div class="acard">
+        <h2><svg class="ic"><use href="#i-plug"/></svg> Connexion</h2>
+        <label>Repo <small>(owner/nom)</small><input id="repo" type="text" placeholder="GaspardCoche/agent-system" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+        <label>Token GitHub <small>(classic, scope repo)</small><input id="pat" type="password" placeholder="ghp_…" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+        <button id="save-settings" class="primary">Enregistrer &amp; tester</button>
+        <p id="settings-msg" class="msg"></p>
+      </div>
+
+      <div class="acard">
+        <h2><svg class="ic"><use href="#i-check"/></svg> Santé des systèmes</h2>
+        <div id="health-token" class="health-token">Chargement…</div>
+        <div id="health-grid" class="kgrid"></div>
+        <button id="health-refresh" class="ghost"><svg class="ic"><use href="#i-clock"/></svg> Tester maintenant</button>
+        <p id="health-msg" class="msg"></p>
+        <h3 class="sub-h">Coût réel</h3>
+        <div id="cost-box"></div>
+      </div>
+
+      <div class="acard">
+        <h2><svg class="ic"><use href="#i-plug"/></svg> Outils &amp; MCP</h2>
+        <p class="hint">Étends les capacités de Claude Pocket : ajoute des serveurs MCP (outils). Ils sont chargés automatiquement à chaque tâche.</p>
+        <ul id="mcp-list" class="mcp-list"></ul>
+        <button id="mcp-new" class="ghost"><svg class="ic"><use href="#i-plus"/></svg> Ajouter un serveur MCP</button>
+        <div id="mcp-editor" class="mcp-editor hidden">
+          <label>Nom <small>(identifiant, sans espace)</small><input id="mcp-name" type="text" placeholder="playwright" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+          <label>Type
+            <div class="seg" id="mcp-transport">
+              <button data-t="stdio" class="active">Commande (stdio)</button>
+              <button data-t="http">HTTP</button>
+            </div>
+          </label>
+          <div id="mcp-stdio">
+            <label>Commande <input id="mcp-command" type="text" placeholder="npx" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+            <label>Arguments <small>(un par ligne)</small><textarea id="mcp-args" rows="2" placeholder="-y&#10;@playwright/mcp@latest"></textarea></label>
+          </div>
+          <div id="mcp-http" class="hidden">
+            <label>URL <input id="mcp-url" type="text" placeholder="https://serveur/mcp" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+            <label>En-têtes <small>(clé: valeur, un par ligne)</small><textarea id="mcp-headers" rows="2" placeholder="X-API-Key: ..."></textarea></label>
+          </div>
+          <label>Variables d'environnement <small>(clé=valeur, un par ligne — optionnel)</small><textarea id="mcp-env" rows="2" placeholder="TOKEN=..."></textarea></label>
+          <label>Outils autorisés <small>(noms séparés par virgule, ou * pour tous)</small><input id="mcp-tools" type="text" placeholder="*" autocapitalize="off" autocorrect="off" spellcheck="false" /></label>
+          <div class="editor-actions">
+            <button id="mcp-save" class="primary"><svg class="ic"><use href="#i-check"/></svg> Enregistrer</button>
+            <button id="mcp-delete" class="ghost danger hidden"><svg class="ic"><use href="#i-trash"/></svg> Supprimer</button>
+          </div>
+          <p id="mcp-msg" class="msg"></p>
+        </div>
+      </div>
+
+      <div class="acard">
+        <h2><svg class="ic"><use href="#i-brain"/></svg> Connaissances</h2>
+        <p class="hint">Ce que Pocket a appris, par domaine. Éditable.</p>
+        <label>Domaine
+          <select id="know-domain">
+            <option value="crm">CRM</option><option value="enrich">Enrichissement</option>
+            <option value="content">Contenu</option><option value="web">Web</option>
+            <option value="vault">Vault</option><option value="other">Autre</option>
           </select>
         </label>
-        <label>Demande à lancer automatiquement
-          <textarea id="mode-sched-demande" rows="2" placeholder="Ex : Lance l'audit CRM hebdomadaire."></textarea>
-        </label>
-        <p class="hint" style="margin-top:0">Lecture seule (les tâches programmées ne font pas d'écriture sans toi). Fuseau : Europe/Brussels. Tu recevras une notif à la fin.</p>
+        <textarea id="know-text" rows="8" placeholder="(vide — Pocket apprendra au fil des tâches)"></textarea>
+        <button id="know-save" class="ghost"><svg class="ic"><use href="#i-check"/></svg> Enregistrer</button>
+        <p id="know-msg" class="msg"></p>
       </div>
-      <button id="mode-save" class="primary"><svg class="ic"><use href="#i-check"/></svg> Déployer le mode</button>
-      <button id="mode-delete" class="ghost hidden">Supprimer ce mode</button>
-      <p id="mode-msg" class="msg"></p>
-    </div>
-  </section>
 
-  <!-- ── Connaissances (expertise accumulée) ── -->
-  <section id="knowledge" class="card hidden">
-    <button class="link-btn" id="knowledge-back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
-    <h2><svg class="ic"><use href="#i-brain"/></svg> Connaissances accumulées</h2>
-    <p class="hint" style="margin-top:0">Ce que Pocket a appris par domaine. Tu peux corriger ou élaguer.</p>
-    <label>Domaine
-      <select id="know-domain">
-        <option value="crm">CRM</option><option value="web">Web</option><option value="vault">Vault</option>
-        <option value="enrich">Enrichissement</option><option value="outreach">Outreach</option>
-        <option value="code">Code</option><option value="other">Autre</option>
-      </select>
-    </label>
-    <textarea id="know-text" rows="12" placeholder="(vide — Pocket apprendra au fil des tâches)"></textarea>
-    <button id="know-save" class="primary" style="margin-top:10px"><svg class="ic"><use href="#i-check"/></svg> Enregistrer</button>
-    <p id="know-msg" class="msg"></p>
-  </section>
+      <div class="acard">
+        <h2><svg class="ic"><use href="#i-sun"/></svg> Apparence &amp; notifications</h2>
+        <label>Thème
+          <div class="seg" id="theme-seg">
+            <button data-theme="auto">Auto</button>
+            <button data-theme="light">Clair</button>
+            <button data-theme="dark">Sombre</button>
+          </div>
+        </label>
+        <button id="enable-push" class="ghost"><svg class="ic"><use href="#i-bell"/></svg> Activer les notifications</button>
+        <p id="push-msg" class="msg"></p>
+      </div>
 
-  <!-- ── Dashboard (command center) ── -->
-  <section id="dashboard" class="card dash">
-    <div class="dash-head">
-      <div class="dash-stats" id="dash-stats"></div>
-      <button class="icon-btn" id="refresh-btn" title="Rafraîchir"><svg class="ic"><use href="#i-clock"/></svg></button>
-    </div>
-    <div id="dash-domains" class="dash-domains"></div>
-  </section>
-
-  <!-- ── Composer ── -->
-  <section id="composer" class="card">
-    <h2><svg class="ic"><use href="#i-send"/></svg> Nouvelle tâche</h2>
-    <div class="chips" id="mode-chips"></div>
-    <div class="textarea-wrap">
-      <textarea id="demande" rows="4" placeholder="Décris ta demande en langage naturel… (ex : combien de leads en France ?)"></textarea>
-      <button id="mic" class="icon-btn mic" title="Dicter"><svg class="ic"><use href="#i-mic"/></svg></button>
-    </div>
-    <p id="mic-hint" class="hint hidden">Astuce dictée : tu peux aussi toucher le champ puis le micro du clavier iOS.</p>
-    <input id="file-input" type="file" multiple class="hidden" />
-    <button id="attach-btn" class="ghost" style="margin-top:8px"><svg class="ic"><use href="#i-clip"/></svg> Joindre un fichier (CSV, doc…)</button>
-    <div id="file-list" class="file-list"></div>
-    <div class="chips" id="chips">
-      <button class="chip" data-q="Combien de contacts par lifecyclestage ?">Stats CRM</button>
-      <button class="chip" data-q="Liste mes phantoms PhantomBuster et leur dernier run.">PhantomBuster</button>
-      <button class="chip" data-q="Donne les stats de mes campagnes Lemlist.">Lemlist</button>
-    </div>
-    <div class="row">
-      <label class="toggle"><input id="write-allowed" type="checkbox" /><span>Autoriser l'écriture</span></label>
-    </div>
-    <label id="conditions-wrap" class="hidden">Conditions d'écriture
-      <textarea id="conditions" rows="2" placeholder="Ex : mets lifecyclestage à 'lead', jamais l'écraser."></textarea>
-    </label>
-    <button id="dispatch" class="primary big"><svg class="ic"><use href="#i-send"/></svg> Dispatch</button>
-    <p id="composer-msg" class="msg"></p>
-  </section>
-
-  <!-- ── Historique (classé par système) ── -->
-  <section id="history" class="card">
-    <h2><svg class="ic"><use href="#i-list"/></svg> Tâches récentes</h2>
-    <div class="seg" id="source-filter">
-      <button data-src="phone" class="active">📱 Téléphone</button>
-      <button data-src="scheduled">⏰ Programmé</button>
-      <button data-src="computer">💻 Ordinateur</button>
-      <button data-src="all">Tout</button>
-    </div>
-    <div class="chips" id="cat-filters"></div>
-    <ul id="history-list"></ul>
-  </section>
-
-  <!-- ── Détail tâche + console + monitoring ── -->
-  <section id="detail" class="card hidden">
-    <button class="link-btn" id="back"><svg class="ic"><use href="#i-back"/></svg> Retour</button>
-    <h2 id="detail-title">Tâche</h2>
-    <div id="run-status" class="status-bar idle">Chargement…</div>
-    <div id="live-activity" class="live-activity hidden"></div>
-    <div id="monitor" class="monitor"></div>
-    <a id="run-link" class="run-link hidden" target="_blank" rel="noopener">Voir les logs détaillés ↗</a>
-    <div id="comments"></div>
-    <button id="approve" class="primary hidden"><svg class="ic"><use href="#i-check"/></svg> Approuver l'écriture</button>
-    <p id="detail-msg" class="msg"></p>
-    <div class="chatbar">
-      <textarea id="chat-input" rows="1" placeholder="Réponds ou affine le résultat… (itère)"></textarea>
-      <button id="chat-send" class="icon-btn" title="Envoyer"><svg class="ic"><use href="#i-send"/></svg></button>
-    </div>
-  </section>
+      <details class="acard sys-card">
+        <summary><svg class="ic"><use href="#i-cpu"/></svg> Système <span class="ver" id="ver-badge">v16</span></summary>
+        <div id="system-grid" class="kgrid"></div>
+      </details>
+    </section>
+  </main>
 
   <script src="app.js"></script>
 </body>

--- a/docs/pocket/manifest.webmanifest
+++ b/docs/pocket/manifest.webmanifest
@@ -1,12 +1,12 @@
 {
   "name": "Claude Pocket",
   "short_name": "Pocket",
-  "description": "Déclencher les agents Claude depuis le téléphone",
+  "description": "Claude sur ton téléphone — CRM, enrichissement, contenu",
   "start_url": ".",
   "scope": ".",
   "display": "standalone",
-  "background_color": "#0b0f17",
-  "theme_color": "#0b0f17",
+  "background_color": "#1b1815",
+  "theme_color": "#1b1815",
   "icons": [
     { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
   ]

--- a/docs/pocket/style.css
+++ b/docs/pocket/style.css
@@ -1,222 +1,277 @@
-/* ── Thèmes ────────────────────────────────────────────────────────────── */
+/* ══════════════════════════════════════════════════════════════════════════
+   Claude Pocket v16 — interface Claude mobile
+   Direction : premium chaleureux, éditorial, chat-first. Accent argile Claude.
+   Titrage sérif natif (New York/ui-serif), corps SF. Aucun emoji.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 :root {
-  --bg: #0a0e16; --card: #121826; --card2: #1a2233; --line: #232d40;
-  --text: #e7edf5; --muted: #8a97ab; --accent: #6aa3ff; --accent2: #3b6fd4;
-  --ok: #3fb950; --warn: #d29922; --err: #f85149;
-  --bubble-user: #15294a; --accent-soft: #122039;
-  --shadow: 0 6px 20px rgba(0,0,0,.28);
-  --radius: 18px;
+  --serif: ui-serif, "New York", Georgia, "Times New Roman", serif;
+  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono: "SF Mono", ui-monospace, Menlo, monospace;
+
+  --bg: #1b1815; --bg2: #211d19; --surface: #26221d;
+  --elev: #302a23; --line: #3b342c; --line-soft: #322c25;
+  --text: #f2ede4; --muted: #a99f8f; --faint: #786d5f;
+  --accent: #d97757; --accent-2: #e79070; --accent-ink: #1b1815;
+  --accent-soft: rgba(217,119,87,.14);
+  --ok: #86b06a; --warn: #d7a44b; --err: #de7b63;
+  --user-bubble: #322a22; --shadow: 0 10px 30px rgba(0,0,0,.28);
+  --radius: 17px; --radius-sm: 12px;
 }
 :root[data-theme="light"] {
-  --bg: #eef1f7; --card: #ffffff; --card2: #f2f5fa; --line: #dce3ef;
-  --text: #16202e; --muted: #5d6982; --accent: #2f6fe0; --accent2: #1f55bd;
-  --bubble-user: #dce9fd; --accent-soft: #e9f1ff; --shadow: 0 6px 18px rgba(40,60,100,.10);
+  --bg: #f4efe6; --bg2: #efe8dd; --surface: #fffdf9; --elev: #fbf6ee;
+  --line: #e6ddcd; --line-soft: #ede5d8;
+  --text: #2b2621; --muted: #7c7264; --faint: #a79c8c;
+  --accent: #bf5c38; --accent-2: #a94e2e; --accent-ink: #fffdf9;
+  --accent-soft: rgba(191,92,56,.10);
+  --ok: #5c8a44; --warn: #b17c2b; --err: #c0563c;
+  --user-bubble: #efe6d7; --shadow: 0 8px 26px rgba(70,50,30,.10);
 }
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
-    --bg: #eef1f7; --card: #ffffff; --card2: #f2f5fa; --line: #dce3ef;
-    --text: #16202e; --muted: #5d6982; --accent: #2f6fe0; --accent2: #1f55bd;
-    --bubble-user: #dce9fd; --accent-soft: #e9f1ff; --shadow: 0 6px 18px rgba(40,60,100,.10);
+    --bg: #f4efe6; --bg2: #efe8dd; --surface: #fffdf9; --elev: #fbf6ee;
+    --line: #e6ddcd; --line-soft: #ede5d8;
+    --text: #2b2621; --muted: #7c7264; --faint: #a79c8c;
+    --accent: #bf5c38; --accent-2: #a94e2e; --accent-ink: #fffdf9;
+    --accent-soft: rgba(191,92,56,.10);
+    --ok: #5c8a44; --warn: #b17c2b; --err: #c0563c;
+    --user-bubble: #efe6d7; --shadow: 0 8px 26px rgba(70,50,30,.10);
   }
 }
 
-* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
-html, body { margin: 0; background: var(--bg); }
+* { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+html { -webkit-text-size-adjust: 100%; }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
-  color: var(--text); padding: env(safe-area-inset-top) 14px calc(env(safe-area-inset-bottom) + 28px);
-  max-width: 680px; margin: 0 auto; -webkit-font-smoothing: antialiased;
-  transition: background .25s, color .25s;
+  font-family: var(--sans); background: var(--bg); color: var(--text);
+  line-height: 1.5; font-size: 15px; overflow-x: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
+  background-image: radial-gradient(120% 60% at 85% -8%, var(--accent-soft), transparent 60%);
+  background-attachment: fixed;
 }
-.ic { width: 18px; height: 18px; display: inline-block; vertical-align: -3px; }
-
-/* ── Header ─────────────────────────────────────────────────────────────── */
-header {
-  position: sticky; top: 0; z-index: 10;
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 16px 4px 12px; margin-bottom: 8px;
-  background: linear-gradient(var(--bg) 72%, transparent);
-}
-.brand { font-size: 18px; font-weight: 750; letter-spacing: -.015em; display: flex; align-items: center; gap: 9px; cursor: pointer; background: none; color: var(--text); padding: 0; }
-.brand .logo { width: 26px; height: 26px; border-radius: 8px; flex: 0 0 auto; }
-.dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); }
-.dot.ok { background: var(--ok); } .dot.err { background: var(--err); }
-.ver { font-size: 10px; color: var(--muted); font-weight: 600; background: var(--card2); border: 1px solid var(--line); padding: 2px 6px; border-radius: 6px; }
-.hbtns { display: flex; gap: 8px; }
-
-/* ── Cartes ─────────────────────────────────────────────────────────────── */
-.card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px; margin-bottom: 14px; box-shadow: var(--shadow); }
-h2 { font-size: 12.5px; margin: 0 0 14px; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700; display: flex; align-items: center; gap: 8px; }
-h2 .ic { width: 15px; height: 15px; color: var(--accent); }
-
-label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 12px; }
-label small { font-weight: 400; opacity: .65; }
-input[type=text], input[type=password], textarea {
-  width: 100%; margin-top: 6px; padding: 13px; background: var(--card2); border: 1px solid var(--line);
-  border-radius: 12px; color: var(--text); font-size: 16px; font-family: inherit; transition: border-color .15s;
-}
-input:focus, textarea:focus { outline: none; border-color: var(--accent); }
-textarea { resize: vertical; line-height: 1.45; }
-.textarea-wrap { position: relative; }
-.textarea-wrap .mic { position: absolute; right: 8px; bottom: 8px; }
-
-.row { display: flex; gap: 12px; align-items: center; justify-content: space-between; }
-.toggle { display: flex; align-items: center; gap: 9px; margin: 6px 0 12px; color: var(--text); }
-.toggle input { width: 22px; height: 22px; accent-color: var(--accent2); }
-
-/* ── Boutons ────────────────────────────────────────────────────────────── */
-button { cursor: pointer; font-family: inherit; border: none; }
-.primary { width: 100%; padding: 14px; border-radius: 13px; font-size: 15px; font-weight: 650; color: #fff; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; gap: 8px; box-shadow: 0 4px 14px rgba(59,111,212,.35); transition: filter .12s, transform .08s; }
-.primary:active { filter: brightness(1.1); transform: scale(.99); }
-.primary.big { padding: 16px; font-size: 16px; margin-top: 8px; }
-.primary .ic { color: #fff; }
-.ghost { width: 100%; margin-top: 12px; padding: 12px; border-radius: 12px; background: var(--card2); color: var(--text); border: 1px solid var(--line); font-size: 14px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 8px; }
-.ghost .ic { color: var(--accent); }
-.icon-btn { background: var(--card2); border: 1px solid var(--line); border-radius: 12px; color: var(--text); width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; transition: background .12s; }
-.icon-btn:active { background: var(--line); }
-.icon-btn .ic { color: var(--text); }
-.icon-btn.mic.live { background: #4a1d1d; border-color: var(--err); }
-.icon-btn.mic.live .ic { color: #ff8a80; }
-.link-btn { background: none; color: var(--accent); font-size: 14px; padding: 0 0 12px; display: inline-flex; align-items: center; gap: 6px; }
-.link-btn .ic { color: var(--accent); width: 16px; height: 16px; }
-
+button, input, textarea, select { font-family: inherit; font-size: inherit; color: inherit; }
+button { cursor: pointer; border: none; background: none; }
 .hidden { display: none !important; }
-.hint { font-size: 12px; color: var(--muted); margin: 10px 0 0; line-height: 1.5; }
-.msg { font-size: 13px; margin: 10px 0 0; min-height: 16px; line-height: 1.5; white-space: pre-wrap; }
-.msg.ok { color: var(--ok); } .msg.err { color: var(--err); }
+.ic { width: 18px; height: 18px; display: inline-block; vertical-align: middle; flex: 0 0 auto; }
 
-/* dashboard (command center) */
-.dash { padding: 15px 16px; }
-.dash-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.dash-stats { display: flex; gap: 20px; }
-.ds { text-align: center; }
-.dsv { font-size: 23px; font-weight: 800; color: var(--text); line-height: 1.1; }
-.dsv.live { color: var(--accent); }
-.dsv.live::after { content: ''; display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); margin-left: 5px; vertical-align: middle; animation: pulse 1s infinite; }
-.dsk { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; margin-top: 2px; }
-.dash-domains { display: flex; gap: 7px; flex-wrap: wrap; margin-top: 13px; }
-.dchip { font-size: 12px; padding: 6px 11px; border-radius: 999px; background: var(--card2); border: 1px solid var(--line); color: var(--text); font-weight: 600; display: inline-flex; align-items: center; gap: 6px; }
-.dchip.active { border-color: var(--accent); background: var(--accent-soft); }
-.dchip b { color: var(--accent); }
-.ddot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
-#source-filter button { font-size: 12px; padding: 9px 4px; gap: 3px; }
-
-/* segmented control */
-.seg { display: flex; margin-top: 6px; background: var(--card2); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
-.seg button { flex: 1; padding: 10px; background: transparent; color: var(--muted); font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center; gap: 5px; }
-.seg button.active { background: var(--accent2); color: #fff; }
-.seg button .ic { width: 14px; height: 14px; }
-
-/* chips */
-.chips { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0 4px; }
-.chip { font-size: 12.5px; padding: 8px 13px; border-radius: 999px; background: var(--card2); color: var(--accent); border: 1px solid var(--line); font-weight: 600; transition: background .12s; }
-.chip:active, .chip.active { background: var(--accent2); color: #fff; }
-
-/* fichiers */
-.file-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
-.file-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12.5px; background: var(--card2); border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px; }
-.file-row .fx { color: var(--text); font-weight: 600; }
-.file-row button { background: none; color: var(--err); font-size: 18px; line-height: 1; padding: 0 4px; }
-
-/* ── Historique ─────────────────────────────────────────────────────────── */
-ul { list-style: none; padding: 0; margin: 0; }
-#history-list li {
-  padding: 13px 14px; background: var(--card2); border: 1px solid var(--line); border-radius: 13px;
-  margin-bottom: 9px; display: flex; justify-content: space-between; align-items: center; gap: 10px;
-  border-left: 3px solid var(--cat, var(--line)); transition: transform .08s;
+/* ── Header ── */
+#topbar {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: calc(env(safe-area-inset-top) + 11px) 16px 11px;
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: saturate(1.4) blur(14px); -webkit-backdrop-filter: saturate(1.4) blur(14px);
+  border-bottom: 1px solid var(--line-soft);
 }
-#history-list li:active { transform: scale(.99); }
-#history-list li .t { font-size: 14.5px; font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
-.badge { font-size: 11px; padding: 4px 9px; border-radius: 999px; white-space: nowrap; font-weight: 700; }
-.badge.open { background: rgba(63,185,80,.16); color: var(--ok); }
-.badge.pending { background: var(--card); color: var(--muted); border: 1px solid var(--line); }
-.cat-badge { font-size: 10.5px; padding: 3px 9px; border-radius: 999px; font-weight: 700; color: #fff; white-space: nowrap; }
-.hgroup { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; margin: 14px 0 8px; }
+.brand { display: flex; align-items: center; gap: 9px; }
+.brand .logo { width: 24px; height: 24px; border-radius: 7px; }
+.wordmark { font-family: var(--serif); font-size: 21px; font-weight: 600; letter-spacing: -.01em; }
+.dot { width: 7px; height: 7px; border-radius: 50%; background: var(--faint); transition: background .3s; }
+.dot.ok { background: var(--ok); box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok) 22%, transparent); }
+.dot.err { background: var(--err); }
+.hbtns { display: flex; gap: 6px; }
+.icon-btn { width: 38px; height: 38px; border-radius: 11px; display: grid; place-items: center; color: var(--muted); transition: background .15s, color .15s, transform .08s; }
+.icon-btn:hover { background: var(--elev); color: var(--text); }
+.icon-btn:active { transform: scale(.92); }
 
-/* ── Console / monitoring ───────────────────────────────────────────────── */
-.status-bar { font-size: 13.5px; font-weight: 650; padding: 12px 14px; border-radius: 13px; margin-bottom: 12px; border: 1px solid var(--line); background: var(--card2); color: var(--text); display: flex; align-items: center; gap: 9px; }
-.status-bar.idle, .status-bar.queued { color: var(--muted); }
-.status-bar.running { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
-.status-bar.running::before { content: ''; width: 9px; height: 9px; border-radius: 50%; background: var(--accent); animation: pulse 1s infinite; flex: 0 0 auto; }
-.status-bar.ok { color: var(--ok); border-color: rgba(63,185,80,.4); background: rgba(63,185,80,.10); }
-.status-bar.err { color: var(--warn); border-color: rgba(210,153,34,.4); background: rgba(210,153,34,.10); }
-@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+main { max-width: 640px; margin: 0 auto; padding: 8px 16px 40px; }
+.view { animation: rise .34s cubic-bezier(.2,.7,.2,1); }
+@keyframes rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
 
-.monitor { margin-bottom: 14px; }
-.kgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-.kcell { background: var(--card2); border: 1px solid var(--line); border-radius: 12px; padding: 11px 12px; }
-.kcell .k { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; display: flex; align-items: center; gap: 6px; }
-.kcell .k .ic { width: 13px; height: 13px; color: var(--muted); }
-.kcell .v { font-size: 15px; font-weight: 700; margin-top: 4px; }
-.kcell .v.sm { font-size: 13px; font-weight: 600; }
-.kcell.wide { grid-column: 1 / -1; }
+/* ── Accueil ── */
+.hero { padding: 26px 4px 18px; }
+.greet { font-family: var(--serif); font-size: 33px; font-weight: 600; letter-spacing: -.02em; line-height: 1.08; }
+.hero .sub { color: var(--muted); margin-top: 9px; font-size: 15px; max-width: 34ch; }
 
-/* jauge (contexte / tokens) */
-.gauge { height: 8px; background: var(--card2); border: 1px solid var(--line); border-radius: 999px; overflow: hidden; margin-top: 7px; }
-.gauge > i { display: block; height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent2)); border-radius: 999px; transition: width .4s; }
-.gauge.warn > i { background: linear-gradient(90deg, var(--warn), var(--err)); }
+.composer {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 14px; box-shadow: var(--shadow);
+}
+.ta-wrap { position: relative; }
+textarea, input[type=text], input[type=password], select {
+  width: 100%; background: var(--bg2); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: 13px 14px; color: var(--text);
+  resize: none; transition: border-color .15s, box-shadow .15s;
+}
+textarea { line-height: 1.45; }
+#demande { min-height: 92px; padding-right: 48px; font-size: 16px; }
+textarea:focus, input:focus, select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.icon-btn.mic { position: absolute; right: 7px; bottom: 7px; width: 36px; height: 36px; border-radius: 10px; background: var(--elev); }
+.icon-btn.mic.live { background: var(--accent); color: #fff; animation: pulse 1.3s infinite; }
+@keyframes pulse { 0%,100% { box-shadow: 0 0 0 0 var(--accent-soft); } 50% { box-shadow: 0 0 0 7px transparent; } }
 
-/* timeline étapes */
-.steps { margin-top: 12px; }
-.step { display: flex; align-items: center; gap: 9px; font-size: 13px; padding: 5px 0; color: var(--muted); }
+.dropzone { display: flex; align-items: center; gap: 10px; margin-top: 10px; padding: 8px; border: 1px dashed var(--line); border-radius: var(--radius-sm); transition: border-color .15s, background .15s; }
+.dropzone.drag { border-color: var(--accent); background: var(--accent-soft); }
+.drop-hint { color: var(--faint); font-size: 12.5px; }
+.file-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.file-list:empty { display: none; }
+.file-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; background: var(--bg2); border: 1px solid var(--line); border-radius: 10px; padding: 8px 11px; font-size: 13px; }
+.file-row .fx { display: flex; align-items: center; gap: 7px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-row .fx .ic { width: 15px; height: 15px; color: var(--muted); }
+.file-row button { color: var(--muted); font-size: 18px; padding: 0 4px; }
+
+.model-row { display: flex; align-items: center; gap: 12px; margin-top: 13px; }
+.model-label { font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: var(--faint); flex: 0 0 auto; }
+.seg { display: inline-flex; background: var(--bg2); border: 1px solid var(--line); border-radius: 11px; padding: 3px; gap: 2px; flex-wrap: wrap; }
+.seg button { padding: 7px 12px; border-radius: 8px; font-size: 13px; font-weight: 550; color: var(--muted); transition: color .15s, background .15s; }
+.seg button.active { background: var(--accent); color: #fff; box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 40%, transparent); }
+
+.write-row { margin-top: 14px; }
+.toggle { display: flex; align-items: center; gap: 10px; font-size: 14px; color: var(--muted); cursor: pointer; }
+.toggle input { display: none; }
+.toggle .track { width: 42px; height: 25px; border-radius: 13px; background: var(--line); position: relative; transition: background .2s; flex: 0 0 auto; }
+.toggle .track::after { content: ""; position: absolute; top: 2.5px; left: 3px; width: 20px; height: 20px; border-radius: 50%; background: #fff; transition: transform .2s; box-shadow: 0 1px 3px rgba(0,0,0,.3); }
+.toggle input:checked + .track { background: var(--accent); }
+.toggle input:checked + .track::after { transform: translateX(16px); }
+#conditions-wrap { margin-top: 11px; }
+
+.primary { width: 100%; padding: 14px; border-radius: 13px; font-size: 15.5px; font-weight: 650; color: var(--accent-ink); background: linear-gradient(135deg, var(--accent-2), var(--accent)); display: flex; align-items: center; justify-content: center; gap: 8px; box-shadow: 0 5px 16px color-mix(in srgb, var(--accent) 38%, transparent); transition: filter .12s, transform .08s; }
+.primary:active { transform: translateY(1px) scale(.995); filter: brightness(1.05); }
+.primary .ic { color: var(--accent-ink); }
+.primary.big { margin-top: 14px; }
+.ghost { width: 100%; padding: 12px; border-radius: 12px; font-weight: 550; color: var(--accent); background: var(--elev); border: 1px solid var(--line); display: flex; align-items: center; justify-content: center; gap: 8px; transition: background .15s, transform .08s; }
+.ghost:active { transform: scale(.99); }
+.ghost .ic { color: var(--accent); }
+.ghost.danger { color: var(--err); } .ghost.danger .ic { color: var(--err); }
+
+.chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.chip { padding: 9px 13px; border-radius: 999px; background: var(--bg2); border: 1px solid var(--line); color: var(--text); font-size: 13px; font-weight: 500; transition: border-color .15s, transform .08s; display: inline-flex; align-items: center; gap: 6px; }
+.chip:active { transform: scale(.96); }
+.chip .ic { width: 15px; height: 15px; color: var(--muted); }
+.ghost-chip { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 30%, var(--line)); }
+
+.msg { margin-top: 10px; font-size: 13px; color: var(--muted); white-space: pre-line; min-height: 1px; }
+.msg.ok { color: var(--ok); } .msg.err { color: var(--err); }
+.hint { color: var(--muted); font-size: 13px; margin: 4px 0 12px; }
+
+/* ── Conversations récentes ── */
+.recent { margin-top: 26px; }
+.recent-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 12px; }
+.recent-head h2 { font-family: var(--serif); font-size: 20px; font-weight: 600; }
+.mini-stats { display: flex; gap: 14px; font-size: 12px; color: var(--faint); }
+.mini-stats b { color: var(--accent); font-weight: 650; }
+.mini-stats .live b { animation: blink 1.4s infinite; }
+@keyframes blink { 50% { opacity: .4; } }
+.thread-list { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+.thread-list li { display: flex; align-items: center; gap: 12px; background: var(--surface); border: 1px solid var(--line); border-left: 3px solid var(--cat, var(--line)); border-radius: 13px; padding: 13px 14px; transition: transform .1s, border-color .15s; }
+.thread-list li:active { transform: scale(.99); }
+.thread-list li.empty { justify-content: center; color: var(--faint); border-left-color: var(--line); font-size: 13.5px; padding: 22px; }
+.thread-list .t { flex: 1; font-size: 14.5px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.thread-list .meta-r { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+.cat-badge { font-size: 10.5px; font-weight: 650; color: #fff; padding: 3px 8px; border-radius: 999px; letter-spacing: .02em; }
+.st { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+.st.open { background: var(--ok); } .st.done { background: var(--faint); }
+
+/* ── Conversation (détail) ── */
+.detail-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding-top: 6px; }
+.link-btn { color: var(--accent); font-size: 14px; display: inline-flex; align-items: center; gap: 6px; font-weight: 550; }
+.link-btn .ic { color: var(--accent); width: 17px; height: 17px; }
+.conv-title { font-family: var(--serif); font-size: 22px; font-weight: 600; margin: 12px 0 14px; letter-spacing: -.01em; }
+.status-pill { font-size: 12.5px; font-weight: 600; padding: 6px 12px; border-radius: 999px; display: inline-flex; align-items: center; gap: 7px; }
+.status-pill::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+.status-pill.idle { background: var(--elev); color: var(--muted); }
+.status-pill.queued { background: color-mix(in srgb, var(--warn) 16%, transparent); color: var(--warn); }
+.status-pill.running { background: var(--accent-soft); color: var(--accent); }
+.status-pill.running::before { animation: blink 1s infinite; }
+.status-pill.ok { background: color-mix(in srgb, var(--ok) 16%, transparent); color: var(--ok); }
+.status-pill.err { background: color-mix(in srgb, var(--err) 16%, transparent); color: var(--err); }
+
+.live-activity { font-size: 13px; color: var(--accent); background: var(--accent-soft); border-radius: 11px; padding: 9px 13px; margin-bottom: 12px; display: flex; align-items: center; gap: 8px; }
+.live-activity::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); animation: blink 1s infinite; flex: 0 0 auto; }
+
+.chat { display: flex; flex-direction: column; gap: 12px; }
+.comment { max-width: 92%; animation: bubble-in .28s cubic-bezier(.2,.7,.2,1); }
+@keyframes bubble-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+.comment.user { align-self: flex-end; }
+.comment.assistant { align-self: flex-start; }
+.comment .who { font-size: 11px; color: var(--faint); margin: 0 4px 4px; font-weight: 500; }
+.comment.user .who { text-align: right; }
+.comment .md { padding: 12px 15px; border-radius: 16px; font-size: 15px; overflow-wrap: anywhere; }
+.comment.user .md { background: var(--user-bubble); border: 1px solid var(--line); border-bottom-right-radius: 5px; }
+.comment.assistant .md { background: var(--surface); border: 1px solid var(--line); border-bottom-left-radius: 5px; box-shadow: var(--shadow); }
+.comment.progress { align-self: center; max-width: 100%; opacity: .82; }
+.comment.progress .who { display: none; }
+.comment.progress .md { background: transparent; border: none; box-shadow: none; color: var(--muted); font-size: 13px; padding: 2px 8px; font-style: italic; }
+
+/* Markdown dans les bulles */
+.md > *:first-child { margin-top: 0; } .md > *:last-child { margin-bottom: 0; }
+.md p { margin: 8px 0; } .md .md-h { font-family: var(--serif); margin: 14px 0 7px; font-weight: 600; line-height: 1.25; }
+.md h1.md-h { font-size: 20px; } .md h2.md-h { font-size: 18px; } .md h3.md-h { font-size: 16px; }
+.md ul, .md ol { margin: 8px 0; padding-left: 20px; } .md li { margin: 3px 0; }
+.md code { font-family: var(--mono); font-size: .86em; background: var(--bg2); padding: 2px 5px; border-radius: 5px; }
+.md pre { background: var(--bg2); border: 1px solid var(--line); border-radius: 11px; padding: 12px; overflow-x: auto; margin: 10px 0; }
+.md pre code { background: none; padding: 0; font-size: 12.5px; }
+.md blockquote { border-left: 3px solid var(--accent); padding-left: 12px; margin: 10px 0; color: var(--muted); }
+.md a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); }
+.md a.dl { display: inline-flex; align-items: center; gap: 7px; background: var(--accent-soft); color: var(--accent); padding: 8px 13px; border-radius: 10px; border: none; font-weight: 600; margin: 6px 0; }
+.md a.dl .ic { width: 16px; height: 16px; color: var(--accent); }
+.md table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 13px; display: block; overflow-x: auto; }
+.md th, .md td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; white-space: nowrap; }
+.md th { background: var(--bg2); font-weight: 650; }
+.md hr { border: none; border-top: 1px solid var(--line); margin: 12px 0; }
+
+.monitor-wrap { margin: 16px 0 8px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); }
+.monitor-wrap summary { padding: 12px 14px; font-size: 13px; font-weight: 550; color: var(--muted); cursor: pointer; list-style: none; }
+.monitor-wrap summary::-webkit-details-marker { display: none; }
+.monitor-wrap[open] summary { border-bottom: 1px solid var(--line); }
+.monitor { padding: 12px 14px; }
+.steps { margin-top: 10px; display: flex; flex-direction: column; gap: 3px; }
+.step { display: flex; align-items: center; gap: 9px; font-size: 12.5px; color: var(--faint); padding: 3px 0; }
 .step .sdot { width: 7px; height: 7px; border-radius: 50%; background: var(--line); flex: 0 0 auto; }
-.step.done { color: var(--text); } .step.done .sdot { background: var(--ok); }
-.step.cur { color: var(--accent); } .step.cur .sdot { background: var(--accent); animation: pulse 1s infinite; }
+.step.done { color: var(--muted); } .step.done .sdot { background: var(--ok); }
+.step.cur { color: var(--accent); } .step.cur .sdot { background: var(--accent); animation: blink 1s infinite; }
+.run-link { display: inline-block; margin: 0 14px 12px; font-size: 12.5px; color: var(--accent); }
 
-/* ── Chat ───────────────────────────────────────────────────────────────── */
-#comments { display: flex; flex-direction: column; gap: 9px; }
-.comment { border: 1px solid var(--line); border-radius: 15px; padding: 12px 14px; font-size: 14px; white-space: pre-wrap; word-break: break-word; line-height: 1.5; max-width: 88%; }
-.comment.assistant { background: var(--card2); align-self: flex-start; border-bottom-left-radius: 5px; }
-.comment.user { background: var(--bubble-user); border-color: var(--accent2); align-self: flex-end; border-bottom-right-radius: 5px; }
-.comment.progress { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); font-weight: 600; align-self: flex-start; }
-.comment .who { font-size: 11px; color: var(--muted); margin-bottom: 6px; }
-.comment.user .who { color: var(--accent); }
-.comment a { color: var(--accent); }
-.comment a.dl { display: inline-flex; align-items: center; gap: 6px; margin-top: 8px; padding: 9px 14px; background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #fff; border-radius: 10px; font-weight: 650; text-decoration: none; }
-/* rendu markdown dans les bulles */
-.comment .md { white-space: normal; }
-.comment .md > *:first-child { margin-top: 0; }
-.comment .md > *:last-child { margin-bottom: 0; }
-.comment .md p { margin: 7px 0; }
-.comment .md .md-h { font-size: 15px; font-weight: 750; margin: 11px 0 5px; color: var(--text); text-transform: none; letter-spacing: 0; display: block; }
-.comment .md code { background: var(--bg); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; font-size: 12.5px; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
-.comment .md pre { background: var(--bg); border: 1px solid var(--line); border-radius: 10px; padding: 11px; overflow-x: auto; margin: 8px 0; }
-.comment .md pre code { background: none; border: none; padding: 0; font-size: 12px; }
-.comment .md table { border-collapse: collapse; width: 100%; font-size: 12.5px; margin: 8px 0; display: block; overflow-x: auto; }
-.comment .md th, .comment .md td { border: 1px solid var(--line); padding: 6px 9px; text-align: left; white-space: nowrap; }
-.comment .md th { background: var(--bg); font-weight: 700; }
-.comment .md ul, .comment .md ol { margin: 6px 0; padding-left: 20px; }
-.comment .md li { margin: 3px 0; }
-.comment .md blockquote { border-left: 3px solid var(--accent); padding-left: 11px; margin: 8px 0; color: var(--muted); }
-.comment .md hr { border: none; border-top: 1px solid var(--line); margin: 11px 0; }
-.empty { color: var(--muted); font-size: 13px; }
+.chatbar { position: sticky; bottom: 0; display: flex; gap: 8px; align-items: flex-end; padding: 12px 0 calc(env(safe-area-inset-bottom) + 8px); background: linear-gradient(to top, var(--bg) 62%, transparent); margin-top: 12px; }
+.chatbar textarea { flex: 1; max-height: 130px; border-radius: 14px; background: var(--surface); }
+.icon-btn.send { width: 46px; height: 46px; border-radius: 13px; background: var(--accent); color: #fff; }
+.icon-btn.send .ic { color: #fff; }
 
-.chatbar { display: flex; gap: 8px; align-items: flex-end; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line); }
-.chatbar textarea { flex: 1; margin: 0; min-height: 46px; max-height: 140px; border-radius: 14px; }
-.chatbar .icon-btn { width: 48px; height: 48px; flex: 0 0 auto; background: linear-gradient(135deg, var(--accent), var(--accent2)); border: none; box-shadow: 0 4px 12px rgba(59,111,212,.3); }
-.chatbar .icon-btn .ic { color: #fff; }
+/* ── kgrid (santé / système) ── */
+.kgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.kcell { background: var(--bg2); border: 1px solid var(--line); border-radius: 11px; padding: 11px 12px; }
+.kcell.wide { grid-column: 1 / -1; }
+.kcell .k { font-size: 11.5px; color: var(--muted); display: flex; align-items: center; gap: 6px; }
+.kcell .k .ic { width: 14px; height: 14px; color: var(--faint); }
+.kcell .v { font-size: 16px; font-weight: 600; margin-top: 3px; } .kcell .v.sm { font-size: 14px; }
 
-/* activité live + lien logs */
-.live-activity { font-size: 13.5px; font-weight: 600; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent); border-radius: 13px; padding: 11px 13px; margin-bottom: 12px; display: flex; align-items: center; gap: 10px; }
-.live-activity::before { content: ''; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: pulse 1s infinite; flex: 0 0 auto; }
-.run-link { display: inline-block; font-size: 12.5px; color: var(--muted); margin: 0 0 12px; text-decoration: none; }
+/* ── Administration ── */
+.admin-title { font-family: var(--serif); font-size: 28px; font-weight: 600; margin: 12px 0 18px; letter-spacing: -.02em; }
+.acard { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px; margin-bottom: 14px; box-shadow: var(--shadow); }
+.acard h2 { font-family: var(--serif); font-size: 17px; font-weight: 600; display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.acard h2 .ic { color: var(--accent); width: 17px; height: 17px; }
+.acard .sub-h { font-size: 13px; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); margin: 16px 0 9px; }
+.acard label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 12px; }
+.acard label small { color: var(--faint); font-weight: 400; }
+.acard label input, .acard label textarea, .acard label select { margin-top: 6px; }
+.acard label .seg { margin-top: 7px; display: flex; }
+.acard label .seg button { flex: 1; text-align: center; }
+.editor-actions { display: flex; gap: 10px; } .editor-actions .primary, .editor-actions .ghost { width: auto; flex: 1; }
+.ver { font-family: var(--mono); font-size: 11px; color: var(--faint); background: var(--bg2); padding: 2px 7px; border-radius: 6px; margin-left: auto; }
+.sys-card summary { font-family: var(--serif); font-size: 17px; font-weight: 600; display: flex; align-items: center; gap: 8px; cursor: pointer; list-style: none; }
+.sys-card summary::-webkit-details-marker { display: none; }
+.sys-card summary .ic { color: var(--accent); }
+.sys-card[open] summary { margin-bottom: 12px; }
 
-/* modes */
-#modes-list li { padding: 13px 14px; background: var(--card2); border: 1px solid var(--line); border-radius: 13px; margin-bottom: 9px; border-left: 3px solid var(--cat, var(--accent)); }
-#modes-list li .mh { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
-#modes-list li .mn { font-size: 14.5px; font-weight: 650; }
-#modes-list li .md { font-size: 12.5px; color: var(--muted); margin-top: 4px; line-height: 1.4; }
-#modes-list li .actions { display: flex; gap: 6px; flex: 0 0 auto; }
-#modes-list li .actions button { font-size: 12px; padding: 5px 10px; border-radius: 8px; background: var(--card); border: 1px solid var(--line); color: var(--accent); font-weight: 600; }
-
-section { animation: fade .22s ease; }
-@keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
-
-/* ── Santé des systèmes (v15) ── */
-.health-token { padding: 11px 13px; border-radius: 12px; font-weight: 600; font-size: 14px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--line); margin-bottom: 10px; }
-.health-token small { font-weight: 400; color: var(--muted); margin-left: 4px; }
-.health-token.ok { background: color-mix(in srgb, var(--ok) 13%, transparent); color: var(--ok); border-color: color-mix(in srgb, var(--ok) 35%, transparent); }
+/* Santé */
+.health-token { padding: 12px 14px; border-radius: 12px; font-weight: 600; font-size: 14px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--line); margin-bottom: 10px; }
+.health-token small { font-weight: 400; color: var(--muted); }
+.health-token.ok { background: color-mix(in srgb, var(--ok) 13%, transparent); color: var(--ok); border-color: color-mix(in srgb, var(--ok) 34%, transparent); }
 .health-token.err { background: color-mix(in srgb, var(--err) 14%, transparent); color: var(--err); border-color: color-mix(in srgb, var(--err) 40%, transparent); }
-.health-token .ic { width: 16px; height: 16px; flex: 0 0 auto; }
-.ok-dot { color: var(--ok); } .err-dot { color: var(--err); }
+.health-token .ic { width: 17px; height: 17px; }
+.ok-dot { color: var(--ok); } .err-dot { color: var(--faint); }
+
+/* MCP */
+.mcp-list { list-style: none; display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px; }
+.mcp-list:empty { display: none; }
+.mcp-row { display: flex; align-items: center; gap: 11px; background: var(--bg2); border: 1px solid var(--line); border-radius: 12px; padding: 11px 13px; }
+.mcp-row .mcp-ic { width: 34px; height: 34px; border-radius: 9px; background: var(--accent-soft); color: var(--accent); display: grid; place-items: center; flex: 0 0 auto; }
+.mcp-row .mcp-meta { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.mcp-row .mcp-n { font-weight: 600; font-size: 14px; }
+.mcp-row .mcp-d { font-size: 12px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mcp-row .mcp-badge { font-size: 10.5px; font-weight: 600; padding: 3px 8px; border-radius: 999px; flex: 0 0 auto; }
+.mcp-row .mcp-badge.on { background: color-mix(in srgb, var(--ok) 16%, transparent); color: var(--ok); }
+.mcp-row .mcp-badge.base { background: var(--elev); color: var(--faint); }
+.mcp-row.editable { cursor: pointer; } .mcp-row.editable:active { transform: scale(.99); }
+.mcp-editor { border-top: 1px solid var(--line); margin-top: 12px; padding-top: 14px; }
+
+@media (max-width: 380px) { .greet { font-size: 29px; } .kgrid { grid-template-columns: 1fr; } .seg button { padding: 7px 10px; } }

--- a/docs/pocket/sw.js
+++ b/docs/pocket/sw.js
@@ -1,5 +1,5 @@
 // Service worker — réseau d'abord (évite le cache figé), repli hors-ligne + push.
-const CACHE = 'pocket-v15';
+const CACHE = 'pocket-v16';
 const SHELL = ['./', './index.html', './app.js', './style.css', './icon.svg', './manifest.webmanifest'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
## Incrément 2 — refonte totale du front-end

Claude Pocket devient une véritable **interface Claude sur smartphone**, chat-first.

- **Design** premium chaleureux (palette argile Claude, titrage sérif natif, thèmes clair/sombre), **zéro emoji** → icônes SVG.
- **Navigation** : Accueil (composer + conversations) / Conversation (chat) / Administration.
- **Sélecteur de modèle** (Fable / Opus 4.8 / Sonnet) — écrit `### Modèle:`, lu par le backend v16.
- **Éditeur MCP complet** (base + serveurs utilisateur, stdio/http, env, allowedTools) → `pocket-config/mcp.json`.
- **Santé + coût réel** dans l'Administration ; fichiers glissables, voix, notifications, connaissances.
- Cache SW v16, logo/manifest recolorés.

Vérifié visuellement (accueil + admin, clair + sombre) via captures avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign Claude Pocket into a chat-first mobile Claude interface with a new home, conversation, and administration experience for v16.

New Features:
- Introduce a chat-first home screen with composer, file attachments, voice input, and quick chips for starting conversations.
- Add a per-conversation model selector that writes the chosen model into the issue body for backend v16 consumption.
- Provide an Administration view with health checks, real-time cost overview, system info, and GitHub connection management.
- Add a visual monitoring panel for workflow runs, including live activity, step timeline, and execution details.
- Introduce an MCP server editor that persists configuration to pocket-config/mcp.json, supporting stdio and HTTP transports.
- Add a knowledge editor per domain to manage Pocket’s accumulated expertise.
- Support drag-and-drop file uploads in the mobile interface and integrate them into dispatched conversations.
- Persist the selected Claude model and UI theme in local storage for a personalized experience.

Enhancements:
- Completely overhaul the visual design with a warm premium palette, serif titling, light/dark themes, and SVG-only iconography.
- Simplify navigation into Home (composer + conversations), Conversation detail (chat), and Administration, with improved routing and polling.
- Refine issue history into a conversations list with mini-stats and category badges, removing source-based filtering and legacy modes.
- Improve error and status messaging with a centralized flash helper and compact status pills.
- Streamline push notification enrolment and subscription storage using JSON helpers and the updated cache version.
- Update health and cost computation logic to better surface token health, secret presence, and per-day/month run costs.

Build:
- Bump the service worker cache version to pocket-v16 for the new shell assets and refreshed icon/manifest.